### PR TITLE
Caching a compiled version onSave

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "all",
-    "proseWrap": "always"
+    "proseWrap": "always",
+    "endOfLine": "auto"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,6 +4,5 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "all",
-    "proseWrap": "always",
-    "endOfLine": "auto"
+    "proseWrap": "always"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
-			// "preLaunchTask": "npm: webpack",
+			"preLaunchTask": "npm: webpack",
 		},
 		{
 			"name": "Extension Tests",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "eslint.enable": true
+    "eslint.enable": true,
+    "files.eol": "\n"
 }

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -66,7 +66,7 @@ We recommend installing `Prettier` and `ESLint` VS Code extensions. Before
 commiting, make sure you are passing the following tests:
 
 -   ESLint lint: `npm run lint`.
--   Jest unit tests: `npm run jest`.
+-   Jest unit tests: `npm run test`.
 -   Typescript compilation: `npm run test-compile`.
 -   Pre-publish bundling: `npm run vscode:prepublish`.
 

--- a/package.json
+++ b/package.json
@@ -191,6 +191,12 @@
                     "default": true,
                     "description": "A welcome message is shown when you run a testcase for the first time."
                 },
+                "cph.general.compileOnSave": {
+                    "title": "Compile on Save",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Each time you save the document, the extension will compile it, so a cached version will be ready to be run very fast."
+                },
                 "cph.general.defaultLanguage": {
                     "title": "Default language for new problems",
                     "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,8 @@ import {
 } from './webview/editorChange';
 import { submitToCodeForces, submitToKattis } from './submit';
 import JudgeViewProvider from './webview/JudgeView';
-import { getRetainWebviewContextPref } from './preferences';
+import { getCompileOnSavePref, getRetainWebviewContextPref } from './preferences';
+import { compileOnSave } from './compiler';
 
 let judgeViewProvider: JudgeViewProvider;
 
@@ -106,6 +107,12 @@ export function activate(context: vscode.ExtensionContext) {
                 command: 'new-problem',
                 problem: undefined,
             });
+        }
+    });
+
+    vscode.workspace.onDidSaveTextDocument((e) => {
+        if (getCompileOnSavePref()) {
+            compileOnSave(e);
         }
     });
 

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -11,7 +11,7 @@ export const isResultCorrect = (
     stdout: string,
 ): boolean => {
     const expectedLines = testCase.output.trim().split('\n');
-    const resultLines = stdout.trim().split(EOL);
+    const resultLines = stdout.trim().split(EOL).join('\n').split('\n');
     if (expectedLines.length !== resultLines.length) {
         console.log('Failed precheck', expectedLines, resultLines);
         return false;

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -57,6 +57,9 @@ export const getDefaultLangPref = (): string | null => {
     return pref;
 };
 
+export const getCompileOnSavePref = (): boolean =>
+    getPreference('general.compileOnSave');
+
 export const useShortCodeForcesName = (): boolean => {
     return getPreference('general.useShortCodeForcesName');
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type prefSection =
     | 'general.firstTime'
     | 'general.useShortCodeForcesName'
     | 'general.menuChoices'
+    | 'general.compileOnSave'
     | 'language.c.Args'
     | 'language.c.SubmissionCompiler'
     | 'language.c.Command'
@@ -51,6 +52,7 @@ export type Problem = {
     tests: TestCase[];
     srcPath: string;
     local?: boolean;
+    skipNextCompile?: boolean;
 };
 
 export type Case = {

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -11,7 +11,7 @@ import {
     getAutoShowJudgePref,
     getRetainWebviewContextPref,
 } from '../preferences';
-import { setOnlineJudgeEnv } from '../compiler';
+import { setOnlineJudgeEnv, shouldCompile } from '../compiler';
 
 class JudgeViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'cph.judgeView';
@@ -44,13 +44,17 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                     case 'run-single-and-save': {
                         const problem = message.problem;
                         const id = message.id;
-                        runSingleAndSave(problem, id);
+                        const compile = shouldCompile(message.problem);
+
+                        runSingleAndSave(problem, id, !compile);
                         break;
                     }
 
                     case 'run-all-and-save': {
                         const problem = message.problem;
-                        runAllAndSave(problem);
+                        const compile = shouldCompile(message.problem);
+
+                        runAllAndSave(problem, compile);
                         break;
                     }
 

--- a/src/webview/processRunAll.ts
+++ b/src/webview/processRunAll.ts
@@ -4,16 +4,19 @@ import { compileFile, getBinSaveLocation } from '../compiler';
 import { deleteBinary } from '../executions';
 import { getLanguage } from '../utils';
 import { getJudgeViewProvider } from '../extension';
+import { saveProblem } from '../parser';
 
 /**
  * Run every testcase in a problem one by one. Waits for the first to complete
  * before running next. `runSingleAndSave` takes care of saving.
  **/
-export default async (problem: Problem) => {
+export default async (problem: Problem, compile: boolean) => {
     console.log('Run all started', problem);
-    const didCompile = await compileFile(problem.srcPath);
-    if (!didCompile) {
-        return;
+    if (compile) {
+        const didCompile = await compileFile(problem.srcPath);
+        if (!didCompile) {
+            return;
+        }
     }
     for (const testCase of problem.tests) {
         getJudgeViewProvider().extensionToJudgeViewMessage({
@@ -28,4 +31,11 @@ export default async (problem: Problem) => {
         getLanguage(problem.srcPath),
         getBinSaveLocation(problem.srcPath),
     );
+
+    if (!compile) {
+        // If there was a cached compiled version,
+        // next time it will definitely compile it again
+        problem.skipNextCompile = false;
+        saveProblem(problem.srcPath, problem);
+    }
 };

--- a/src/webview/processRunAll.ts
+++ b/src/webview/processRunAll.ts
@@ -17,7 +17,16 @@ export default async (problem: Problem, compile: boolean) => {
         if (!didCompile) {
             return;
         }
+    } else {
+        // If there was a cached compiled version,
+        // next time it will definitely compile it again
+        problem.skipNextCompile = false;
+        getJudgeViewProvider().extensionToJudgeViewMessage({
+            command: 'new-problem',
+            problem: problem,
+        });
     }
+
     for (const testCase of problem.tests) {
         getJudgeViewProvider().extensionToJudgeViewMessage({
             command: 'running',
@@ -33,9 +42,6 @@ export default async (problem: Problem, compile: boolean) => {
     );
 
     if (!compile) {
-        // If there was a cached compiled version,
-        // next time it will definitely compile it again
-        problem.skipNextCompile = false;
         saveProblem(problem.srcPath, problem);
     }
 };


### PR DESCRIPTION
## Overview

If the user wants to compile and cache a version on each save command, he can do so. This allows them to run the test cases instantly without waiting for it to compile.

## Changes
 - Each problem has one more optional variable `skipNextCompile` which is set to true if the problem is compiled *onSave*
 - When the problem is compiled *onSave* it synchronizes the *JudgeView*
    - Here, we can furthermore improve it by adding an icon in the JudgeView *(I didn't do it)*
 - In the preferences, the user can set this option (compileOnSave) to true, **by default it's false and won't affect anything**.
 - Created `shouldCompile` function which checks if the user wants to `compileOnSave` and if the problem has been already compiled

## How to use it?
 - Enable it in the settings - `compileOnSave`
 - On each save, it will compile.
 - Just click `Run All` or `Run Testcases` and the extension will run the test cases immediately without the need of compiling.
 > Note: The extension will compile the test cases again if the document is `dirty` - means something is changed and not saved.

### Notes
 - The current behaviour is that when a problem is compiled onSave and then the test cases are executed, the variable `skipNextCompile` is reset to false, indicating that the next time the user tries to run the test cases, no matter if it's cached, it will be compiled once again.
 - i.e. the binary is deleted upon each run (as before, no changes there)

### Additional minor fixes:
 - Fixed a comment in the `.vscode/launch.json` - the preLaunchTask was commented out.
 - The command for testing is `npm run test`, not `npm run jest`

### TODO
 - When the pull request is accepted, update the documentation and guide accordingly.