### PR TITLE
Improved readme and dev-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ of popular platforms like Codeforces, Codechef, TopCoder etc.
    in your browser.
 1. Use Companion by pressing the green plus (+) circle from the browser toolbar
    when visiting any problem page.
-1. The file opens in VS Code with testcases preloaded. Press `Ctrl+Alt+B` to run
+1. The file opens in VS Code with testcases preloaded. Press <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>B</kbd> to run
    them.
 
 -   (Optional) Install the [cph-submit](https://github.com/agrawal-d/cph-submit)
@@ -30,7 +30,7 @@ of popular platforms like Codeforces, Codechef, TopCoder etc.
     [Kattis help page](https://open.kattis.com/help/submit) after logging in.
 
 You can also use this extension locally, just open any supported file and press
-'Run Testcases' (or `Ctrl+Alt+B`) to manually enter testcases.
+'Run Testcases' (or <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>B</kbd>) to manually enter testcases.
 
 [![See detailed user guide](https://img.shields.io/badge/-Read%20detailed%20usage%20guide-blue?style=for-the-badge)](docs/user-guide.md)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ of popular platforms like Codeforces, Codechef, TopCoder etc.
    in your browser.
 1. Use Companion by pressing the green plus (+) circle from the browser toolbar
    when visiting any problem page.
-1. The file opens in VS Code with testcases preloaded. Press <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>B</kbd> to run
+1. The file opens in VS Code with testcases preloaded. Press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd> to run
    them.
 
 -   (Optional) Install the [cph-submit](https://github.com/agrawal-d/cph-submit)
@@ -30,7 +30,7 @@ of popular platforms like Codeforces, Codechef, TopCoder etc.
     [Kattis help page](https://open.kattis.com/help/submit) after logging in.
 
 You can also use this extension locally, just open any supported file and press
-'Run Testcases' (or <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>B</kbd>) to manually enter testcases.
+'Run Testcases' (or <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>) to manually enter testcases.
 
 [![See detailed user guide](https://img.shields.io/badge/-Read%20detailed%20usage%20guide-blue?style=for-the-badge)](docs/user-guide.md)
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -11,8 +11,7 @@ user-facingterms.
 The extension runs in a Node.JS context with the
 [VS Code API](https://code.visualstudio.com/api/references/vscode-api). The
 extension shows the results in a web-view (code in `src/webview`). It
-communicates to-and-from the extension by posting messages. See the webview
-API](https://code.visualstudio.com/api/extension-guides/webview) for details.
+communicates to-and-from the extension by posting messages. See the [webview API](https://code.visualstudio.com/api/extension-guides/webview) for details.
 The webview is currently a React App.
 
 It compiles and runs code by spawning binaries, and pipes input to STDIN and


### PR DESCRIPTION
Keyboard Shortcuts  View Improved using `<kbd>` tag

Before : 
`Ctrl+Alt+B`

Now:
<kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>B</kbd>

A typo in dev-guide fixed
