### PR TITLE
Added Support for C++20 submissions on Codeforces and Fixed an Unlikely Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "competitive-programming-helper",
-    "version": "5.7.1",
+    "version": "5.8.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "competitive-programming-helper",
-            "version": "5.7.1",
+            "version": "5.8.7",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "python-shell": "^2.0.2",
@@ -653,7 +653,6 @@
                 "jest-resolve": "^26.0.1",
                 "jest-util": "^26.0.1",
                 "jest-worker": "^26.0.0",
-                "node-notifier": "^7.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -5473,7 +5472,6 @@
                 "@types/graceful-fs": "^4.1.2",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-serializer": "^26.0.0",
                 "jest-util": "^26.0.1",
@@ -10021,10 +10019,8 @@
             "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.0",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.0"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
                         "GNU G++14 6.4.0",
                         "GNU G++11 5.1.0",
                         "GNU G++17 9.2.0 (64 bit, msys 2)",
+                        "GNU G++20 11.2.0 (64 bit, winlibs)",
                         "Microsoft Visual C++ 2017",
                         "Microsoft Visual C++ 2010",
                         "Clang++17 Diagnostics"

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export default {
         'GNU G++14 6.4.0': 50,
         'GNU G++11 5.1.0': 42,
         'GNU G++17 9.2.0 (64 bit, msys 2)': 61,
+        'GNU G++20 11.2.0 (64 bit, winlibs)' : 73,
         'Microsoft Visual C++ 2017': 59,
         'Microsoft Visual C++ 2010': 2,
         'Clang++17 Diagnostics': 52,

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { storeSubmitProblem, submitKattisProblem } from './companion';
 import { getJudgeViewProvider } from './extension';
 
-export const submitToKattis = () => {
+export const submitToKattis = async () => {
     const srcPath = vscode.window.activeTextEditor?.document.fileName;
     if (!srcPath) {
         vscode.window.showErrorMessage(
@@ -11,6 +11,10 @@ export const submitToKattis = () => {
         );
         return;
     }
+
+    const textEditor = await vscode.workspace.openTextDocument(srcPath);
+    await vscode.window.showTextDocument(textEditor, vscode.ViewColumn.One);
+    await textEditor.save();
 
     const problem = getProblem(srcPath);
 
@@ -39,7 +43,7 @@ export const submitToKattis = () => {
     });
 };
 
-export const submitToCodeForces = () => {
+export const submitToCodeForces = async () => {
     const srcPath = vscode.window.activeTextEditor?.document.fileName;
 
     if (!srcPath) {
@@ -48,6 +52,10 @@ export const submitToCodeForces = () => {
         );
         return;
     }
+
+    const textEditor = await vscode.workspace.openTextDocument(srcPath);
+    await vscode.window.showTextDocument(textEditor, vscode.ViewColumn.One);
+    await textEditor.save();
 
     const problem = getProblem(srcPath);
 


### PR DESCRIPTION
I have also tested submitting C++20 code using CPH submit and everything works fine.
![image](https://user-images.githubusercontent.com/76441660/143841921-38ca36ba-420e-4a07-8f9d-92c1566c41f4.png)
Also the submit to codeforces and kattis event didn't save the source file before submitting to OJ's, this has costed me some WA's in the past. I have added the functionality to save the file before submitting.

Also, would it be a nice addition to check if the file had no syntax errors before submitting to OJ's, I don't think there is a builtin method in the vscode workspace API for that. Any suggestions?
