### PR TITLE
 Handle When user sets an invalid path as saveLocation preference

### DIFF
--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -2,6 +2,8 @@ import { workspace } from 'vscode';
 import type { prefSection } from './types';
 import config from './config';
 import path from 'path';
+import fs from 'fs';
+import * as vscode from 'vscode';
 
 const getPreference = (section: prefSection): any => {
     const ret = workspace.getConfiguration('cph').get(section);
@@ -17,8 +19,18 @@ export const updatePreference = (section: prefSection, value: any) => {
 export const getAutoShowJudgePref = (): boolean =>
     getPreference('general.autoShowJudge');
 
-export const getSaveLocationPref = (): string =>
-    getPreference('general.saveLocation');
+export const getSaveLocationPref = (): string => {
+    const pref = getPreference('general.saveLocation');
+    const validSaveLocation = pref == '' || fs.existsSync(pref);
+    if (!validSaveLocation) {
+        vscode.window.showErrorMessage(
+            `Invalid save location, reverting to default. path not exists: ${pref}`,
+        );
+        updatePreference('general.saveLocation', '');
+        return '';
+    }
+    return pref;
+};
 
 export const getIgnoreSTDERRORPref = (): string =>
     getPreference('general.ignoreSTDERROR');

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -11,9 +11,7 @@ const getPreference = (section: prefSection): any => {
 };
 
 export const updatePreference = (section: prefSection, value: any) => {
-    return workspace
-        .getConfiguration('competitive-programming-helper')
-        .update(section, value);
+    return workspace.getConfiguration('cph').update(section, value);
 };
 
 export const getAutoShowJudgePref = (): boolean =>


### PR DESCRIPTION

### Previously
-  clicking on <kbd> Create Problem </kbd> was not giving any response (apparently)
-  only developer tool's console was getting logged with message `no such file or directory`

### After this fix
 - user will be shown a error message stating that path he is trying to use is not valid
 - path is resetted to default ( same directory as source code ) 
 
<img width="474" alt="image" src="https://user-images.githubusercontent.com/63918341/168450714-1ca43fc2-52ad-4bb7-944b-8210d4a54b72.png">

