### PR TITLE
Fix issue #290 for file names in Java

### DIFF
--- a/src/utilsPure.ts
+++ b/src/utilsPure.ts
@@ -2,6 +2,6 @@
 // They can still use VS Code type definitions.
 
 export const words_in_text = function (text: string) {
-    const regex = /[\p{L}-]+|[0-9]+/gu;
+    const regex = /[\p{L}]+|[0-9]+/gu;
     return text.match(regex);
 };


### PR DESCRIPTION
When making a new problem file, cph allows dashes in the file name, this causes problems in Java programs as the class name must match the file name. Java class names do not allow dashes.
The fix is quite simply to stop recognizing the dashes in the regex when parsing a problem.

Fixes: https://github.com/agrawal-d/cph/issues/290