### PR TITLE
Improved file organization

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -34,7 +34,7 @@ export const getBinSaveLocation = (srcPath: string): string => {
     if (savePreference && savePreference !== '') {
         return path.join(savePreference, binFileName);
     }
-    return path.join(binDir, binFileName);
+    return path.join(binDir, '.cph', binFileName);
 };
 
 /**


### PR DESCRIPTION
fixes #165 
This will organize the files into folders into corresponding groups. Each contest will have its own folder, and the code files will be generated into those folders with corresponding file names.
Each contest folder has its own `.cph` folder, containing their corresponding `.prob` files.
The `.bin` files are now generated into their corresponding `.cph` folder by default, keeping the contest folder clean.

![image](https://user-images.githubusercontent.com/43887302/201519029-393f4ece-5a6c-4b85-922d-9dba6ecfc2d9.png)
