### PR TITLE
Update Rust compiler options with "Rust 1.66.0 (2021)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "competitive-programming-helper",
-    "version": "5.7.1",
+    "version": "5.9.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "competitive-programming-helper",
-            "version": "5.7.1",
+            "version": "5.9.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "python-shell": "^2.0.2",
@@ -653,7 +653,6 @@
                 "jest-resolve": "^26.0.1",
                 "jest-util": "^26.0.1",
                 "jest-worker": "^26.0.0",
-                "node-notifier": "^7.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -5473,7 +5472,6 @@
                 "@types/graceful-fs": "^4.1.2",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-serializer": "^26.0.0",
                 "jest-util": "^26.0.1",
@@ -10021,10 +10019,8 @@
             "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.0",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.0"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -155,9 +155,9 @@
                 },
                 "cph.language.rust.SubmissionCompiler": {
                     "type": "string",
-                    "default": "Rust 1.42.0",
+                    "default": "Rust 1.66.0 (2021)",
                     "enum": [
-                        "Rust 1.42.0"
+                        "Rust 1.66.0 (2021)"
                     ],
                     "description": "The compiler chosen in the drop down during Codeforces submission for rust"
                 },

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,7 @@ export default {
         'PyPy 2.7 (7.2.0)': 40,
         'Python 2.7.15': 7,
         'GNU GCC C11 5.1.0': 43,
-        'Rust 1.42.0': 49,
+        'Rust 1.66.0 (2021)': 75,
     },
     supportedExtensions: ['py', 'cpp', 'rs', 'c', 'java'],
     skipCompile: ['py'],


### PR DESCRIPTION
Hi, I just noticed the VSCode extension wasn't working for Rust submissions to Codeforces... I think it's because Codeforces uses a newer Rust compiler than what the extension currently supports. This is my first PR, so let me know if there's anything else you'd like me to change/test, or if there's a better way to get this patch upstream.

I took the ID from [this page](https://codeforces.com/contest/1741/submit), where I found this in the raw html:
`<option value="75" selected="selected">Rust 1.66.0 (2021)</option>`. The previous rust compiler ("Rust 1.42.0") is no longer an option on the Codeforces site.

### Testing

tested by running `vsce package` and installing locally. It submitted this Rust program successfully:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/16356719/218235187-13e249d2-e63f-41fd-9998-5545dbbb1c2f.png">

Also the automated tests seem to pass:
```
$ npm run test

> competitive-programming-helper@5.9.2 pretest
> tsc -p ./


> competitive-programming-helper@5.9.2 test
> jest out/

 PASS  out/tests/utilsPure.test.js
 PASS  out/tests/judge.test.js

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.095 s
```
