### PR TITLE
Add an option to deal with warning of gcc

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
                     "default": 3000,
                     "description": "The time in ms for which a testcase is run before it is killed ( timed-out )."
                 },
+                "cph.general.zeroExitCodeIsWarning": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If enabled, zero exit code when compilation will be considered as warning and will not cause the compilation to fail."
+                },
                 "cph.general.ignoreSTDERROR": {
                     "type": "boolean",
                     "default": false,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2,7 +2,7 @@ import { getLanguage, ocHide, ocShow, ocWrite } from './utils';
 import { Language } from './types';
 import { spawn } from 'child_process';
 import path from 'path';
-import { getSaveLocationPref, getZeroExitCodeIsWarningPref as getZeroExitCodeIsWarningPref } from './preferences';
+import { getSaveLocationPref, getZeroExitCodeIsWarningPref } from './preferences';
 import * as vscode from 'vscode';
 import { getJudgeViewProvider } from './extension';
 export let onlineJudgeEnv = false;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2,7 +2,10 @@ import { getLanguage, ocHide, ocShow, ocWrite } from './utils';
 import { Language } from './types';
 import { spawn } from 'child_process';
 import path from 'path';
-import { getSaveLocationPref, getZeroExitCodeIsWarningPref } from './preferences';
+import {
+    getSaveLocationPref,
+    getZeroExitCodeIsWarningPref,
+} from './preferences';
 import * as vscode from 'vscode';
 import { getJudgeViewProvider } from './extension';
 export let onlineJudgeEnv = false;
@@ -161,8 +164,10 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
         });
 
         compiler.on('exit', (exitcode) => {
-            if ((!getZeroExitCodeIsWarningPref() || exitcode !== 0) 
-                && (exitcode === 1 || error !== '')) { 
+            if (
+                (!getZeroExitCodeIsWarningPref() || exitcode !== 0) &&
+                (exitcode === 1 || error !== '')
+            ) {
                 ocWrite('Errors while compiling:\n' + error);
                 ocShow();
                 console.error('Compilation failed');
@@ -174,7 +179,11 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
                     command: 'not-running',
                 });
                 return;
-            } else if (getZeroExitCodeIsWarningPref() && exitcode === 0 && error !== '') {
+            } else if (
+                getZeroExitCodeIsWarningPref() &&
+                exitcode === 0 &&
+                error !== ''
+            ) {
                 ocWrite('Warnings while compiling:\n' + error);
                 ocShow();
             }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2,7 +2,7 @@ import { getLanguage, ocHide, ocShow, ocWrite } from './utils';
 import { Language } from './types';
 import { spawn } from 'child_process';
 import path from 'path';
-import { getSaveLocationPref } from './preferences';
+import { getSaveLocationPref, getZeroExitCodeIsWarningPref as getZeroExitCodeIsWarningPref } from './preferences';
 import * as vscode from 'vscode';
 import { getJudgeViewProvider } from './extension';
 export let onlineJudgeEnv = false;
@@ -161,7 +161,8 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
         });
 
         compiler.on('exit', (exitcode) => {
-            if (exitcode === 1 || error !== '') {
+            if ((!getZeroExitCodeIsWarningPref() || exitcode !== 0) 
+                && (exitcode === 1 || error !== '')) { 
                 ocWrite('Errors while compiling:\n' + error);
                 ocShow();
                 console.error('Compilation failed');
@@ -173,6 +174,9 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
                     command: 'not-running',
                 });
                 return;
+            } else if (getZeroExitCodeIsWarningPref() && exitcode === 0 && error !== '') {
+                ocWrite('Warnings while compiling:\n' + error);
+                ocShow();
             }
             console.log('Compilation passed');
             getJudgeViewProvider().extensionToJudgeViewMessage({

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -32,6 +32,9 @@ export const getSaveLocationPref = (): string => {
     return pref;
 };
 
+export const getZeroExitCodeIsWarningPref = (): string =>
+    getPreference('general.zeroExitCodeIsWarning');
+
 export const getIgnoreSTDERRORPref = (): string =>
     getPreference('general.ignoreSTDERROR');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type prefSection =
     | 'general.saveLocation'
     | 'general.defaultLanguage'
     | 'general.timeOut'
+    | 'general.zeroExitCodeIsWarning'
     | 'general.ignoreSTDERROR'
     | 'general.firstTime'
     | 'general.useShortCodeForcesName'


### PR DESCRIPTION
This will solve issue #214, #274.

If the exit code of the compiler is 0, and the STDERR is not empty, then we will consider the output of the STDERR is warning message, and the compilation will not be halted, the console will still be displayed with the message "Warnings while compiling".

The function will only be enabled if the new option "Zero Exit Code Is Warning" is enabled in the setting.