### PR TITLE
Add ability to classify problem when handling it at first time.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,12 @@ module.exports = {
     },
     plugins: ['@typescript-eslint', 'prettier'],
     rules: {
-        'prettier/prettier': 'error',
+        'prettier/prettier': [
+            'error',
+            {
+                "endOfLine": "auto"
+            },
+        ],
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/prefer-namespace-keyword': 'off',

--- a/package.json
+++ b/package.json
@@ -249,6 +249,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Automatically show the judge view when opening a file that has a problem associated with it"
+                },
+                "cph.general.enableClassify": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Classify problem in separated folder according to its information"
                 }
             }
         }

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -18,6 +18,8 @@ import { spawn } from 'child_process';
 import { getJudgeViewProvider } from './extension';
 import { words_in_text } from './utilsPure';
 import fs from 'fs';
+import { getEnableClassification } from './preferences';
+
 const emptyResponse: CphEmptyResponse = { empty: true };
 let savedResponse: CphEmptyResponse | CphSubmitResponse = emptyResponse;
 const COMPANION_LOGGING = false;
@@ -254,13 +256,18 @@ const handleNewProblem = async (problem: Problem) => {
         problem.name = splitUrl[splitUrl.length - 1];
     }
     const problemFileName = getProblemFileName(problem, extn);
-    const stem = getProblemStem(problem);
-    const dir = path.join(folder, stem);
-    const srcPath = path.join(folder, stem, problemFileName);
-    if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
+    let srcPath_;
+    if (getEnableClassification()) {
+        const stem = getProblemStem(problem);
+        const dir = path.join(folder, stem);
+        srcPath_ = path.join(folder, stem, problemFileName);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+    } else {
+        srcPath_ = path.join(folder, problemFileName);
     }
-
+    const srcPath = srcPath_;
     // Add fields absent in competitive companion.
     problem.srcPath = srcPath;
     problem.tests = problem.tests.map((testcase) => ({

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -11,7 +11,7 @@ export const isResultCorrect = (
     stdout: string,
 ): boolean => {
     const expectedLines = testCase.output.trim().split('\n');
-    const resultLines = stdout.trim().split('\n');
+    const resultLines = stdout.trim().split(EOL);
     if (expectedLines.length !== resultLines.length) {
         console.log('Failed precheck', expectedLines, resultLines);
         return false;

--- a/src/judge.ts
+++ b/src/judge.ts
@@ -11,7 +11,7 @@ export const isResultCorrect = (
     stdout: string,
 ): boolean => {
     const expectedLines = testCase.output.trim().split('\n');
-    const resultLines = stdout.trim().split(EOL);
+    const resultLines = stdout.trim().split('\n');
     if (expectedLines.length !== resultLines.length) {
         console.log('Failed precheck', expectedLines, resultLines);
         return false;

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -141,3 +141,6 @@ export const getLanguageId = (srcPath: string): number => {
     console.error("Couldn't find id for compiler " + compiler);
     return -1;
 };
+
+export const getEnableClassification = (): boolean =>
+    getPreference('general.enableClassify');

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,8 @@ export type prefSection =
     | 'language.python.Command'
     | 'general.retainWebviewContext'
     | 'general.autoShowJudge'
-    | 'general.defaultLanguageTemplateFileLocation';
+    | 'general.defaultLanguageTemplateFileLocation'
+    | 'general.enableClassify';
 
 export type Language = {
     name: LangNames;


### PR DESCRIPTION
In default, handling a problem will create something in the root folder. It's usable but not enough.
In my case, many projects include cp , are controlled by workspace setting(.vscode),  so a multi tier problem handler is needed.
This pull request makes a change in the problem handing process to let its behavior control by a setting.
When enabled it, base folder will be set to a path depending on problem info, instead of root folder.
When disabled it, nothing to change.
Moreover, a test will fail on windows because of the difference between Windows and Linux EOL.

![manually test](https://github.com/agrawal-d/cph/assets/61844819/cc344084-ec5d-4890-998f-c91410038b30)
