### PR TITLE
Add an option to attach problem to active file

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,6 +254,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Automatically show the judge view when opening a file that has a problem associated with it"
+                },
+                "cph.general.saveProblemToActiveFile": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Choose to save problem to active file when using Competitive Companion"
                 }
             }
         }

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -12,6 +12,7 @@ import {
     useShortCodeForcesName,
     getMenuChoices,
     getDefaultLanguageTemplateFileLocation,
+    getSaveProblemToActiveFile
 } from './preferences';
 import { getProblemName } from './submit';
 import { spawn } from 'child_process';
@@ -201,8 +202,18 @@ const handleNewProblem = async (problem: Problem) => {
         const splitUrl = problem.url.split('/');
         problem.name = splitUrl[splitUrl.length - 1];
     }
+
     const problemFileName = getProblemFileName(problem, extn);
-    const srcPath = path.join(folder, problemFileName);
+    let srcPath;
+    if(getSaveProblemToActiveFile()) {
+        srcPath = vscode.window.activeTextEditor?.document.fileName;
+        if (srcPath == undefined) {
+            vscode.window.showInformationMessage('Please open a file first.');
+            return;
+        }
+    } else {
+        srcPath = path.join(folder, problemFileName);
+    }
 
     // Add fields absent in competitive companion.
     problem.srcPath = srcPath;

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -84,6 +84,9 @@ export const getDefaultLanguageTemplateFileLocation = (): string | null => {
     return pref;
 };
 
+export const getSaveProblemToActiveFile = (): string =>
+    getPreference('general.saveProblemToActiveFile');
+
 export const getCCommand = (): string =>
     getPreference('language.c.Command') || 'gcc';
 export const getCppCommand = (): string =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,8 @@ export type prefSection =
     | 'language.python.Command'
     | 'general.retainWebviewContext'
     | 'general.autoShowJudge'
-    | 'general.defaultLanguageTemplateFileLocation';
+    | 'general.defaultLanguageTemplateFileLocation'
+    | 'general.saveProblemToActiveFile';
 
 export type Language = {
     name: LangNames;


### PR DESCRIPTION
Add an option to attach problem to active file instead of creating a new file in the workspace folder.