### PR TITLE
Support for Haskell (hs, ghc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ enter testcases.
 -   C
 -   Rust
 -   Go
+-   Haskell
 -   Python
 -   Java
 -   JavaScript (Node.js)

--- a/package.json
+++ b/package.json
@@ -191,6 +191,25 @@
                     "default": "go",
                     "description": "Command used to compile .go files."
                 },
+                "cph.language.haskell.Args": {
+                    "title": "Compilation flags for .hs files",
+                    "type": "string",
+                    "default": "",
+                    "description": "Space seperated additional flags passed to go while compiling your file."
+                },
+                "cph.language.haskell.SubmissionCompiler": {
+                    "type": "string",
+                    "default": "Haskell GHC 8.10.1",
+                    "enum": [
+                        "Haskell GHC 8.10.1"
+                    ],
+                    "description": "The compiler chosen in the drop down during Codeforces submission for haskell"
+                },
+                "cph.language.haskell.Command": {
+                    "type": "string",
+                    "default": "ghc",
+                    "description": "Command used to compile .hs files."
+                },
                 "cph.language.java.Args": {
                     "title": "Compilation flags for Java",
                     "type": "string",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -99,6 +99,17 @@ const getFlags = (language: Language, srcPath: string): string[] => {
             ret = [srcPath, '-d', binDir, ...args];
             break;
         }
+        case 'hs': {
+            ret = [
+                srcPath,
+                '-o',
+                getBinSaveLocation(srcPath),
+                '-outputdir',
+                '/tmp/ghc/',
+                ...args,
+            ];
+            break;
+        }
         default: {
             ret = [];
             break;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -104,8 +104,8 @@ const getFlags = (language: Language, srcPath: string): string[] => {
                 srcPath,
                 '-o',
                 getBinSaveLocation(srcPath),
-                '-outputdir',
-                '/tmp/ghc/',
+                '-no-keep-hi-files',
+                '-no-keep-o-files',
                 ...args,
             ];
             break;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export default {
         java: 'java',
         js: 'js',
         go: 'go',
+        hs: 'hs',
     },
     compilers: {
         c: 'gcc',
@@ -24,6 +25,7 @@ export default {
         java: 'javac',
         js: 'node',
         go: 'go',
+        hs: 'hs',
     },
     compilerToId: {
         'GNU G++17 7.3.0': 54,
@@ -45,7 +47,8 @@ export default {
         'GNU GCC C11 5.1.0': 43,
         'Go 1.19.5': 32,
         'Rust 1.66.0 (2021)': 75,
+        'Haskell GHC 8.10.1': 12,
     },
-    supportedExtensions: ['py', 'cpp', 'rs', 'c', 'java', 'js', 'go'],
+    supportedExtensions: ['py', 'cpp', 'rs', 'c', 'java', 'js', 'go', 'hs'],
     skipCompile: ['py', 'js'],
 };

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -53,6 +53,9 @@ export const getCArgsPref = (): string[] =>
 export const getPythonArgsPref = (): string[] =>
     getPreference('language.python.Args').split(' ') || [];
 
+export const getHaskellArgsPref = (): string[] =>
+    getPreference('language.haskell.Args').split(' ') || [];
+
 export const getRustArgsPref = (): string[] =>
     getPreference('language.rust.Args').split(' ') || [];
 
@@ -101,6 +104,8 @@ export const getJsCommand = (): string =>
     getPreference('language.js.Command') || 'node';
 export const getGoCommand = (): string =>
     getPreference('language.go.Command') || 'go';
+export const getHaskellCommand = (): string =>
+    getPreference('language.haskell.Command') || 'ghc';
 
 export const getMenuChoices = (): string[] =>
     getPreference('general.menuChoices').split(' ');
@@ -142,6 +147,11 @@ export const getLanguageId = (srcPath: string): number => {
 
         case '.go': {
             compiler = getPreference('language.go.SubmissionCompiler');
+            break;
+        }
+
+        case '.hs': {
+            compiler = getPreference('language.haskell.SubmissionCompiler');
             break;
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,9 @@ export type prefSection =
     | 'language.python.Args'
     | 'language.python.SubmissionCompiler'
     | 'language.python.Command'
+    | 'language.haskell.Args'
+    | 'language.haskell.SubmissionCompiler'
+    | 'language.haskell.Command'
     | 'general.retainWebviewContext'
     | 'general.autoShowJudge'
     | 'general.defaultLanguageTemplateFileLocation';
@@ -44,7 +47,15 @@ export type Language = {
     skipCompile: boolean;
 };
 
-export type LangNames = 'python' | 'c' | 'cpp' | 'rust' | 'java' | 'js' | 'go';
+export type LangNames =
+    | 'python'
+    | 'c'
+    | 'cpp'
+    | 'rust'
+    | 'java'
+    | 'js'
+    | 'go'
+    | 'hs';
 
 export type TestCase = {
     input: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ import {
     getJavaArgsPref,
     getJsArgsPref,
     getGoArgsPref,
+    getHaskellArgsPref,
     getCCommand,
     getCppCommand,
     getPythonCommand,
@@ -21,6 +22,7 @@ import {
     getJavaCommand,
     getJsCommand,
     getGoCommand,
+    getHaskellCommand,
 } from './preferences';
 import { Language, Problem } from './types';
 import telmetry from './telmetry';
@@ -97,6 +99,14 @@ export const getLanguage = (srcPath: string): Language => {
                 name: langName,
                 args: [...getGoArgsPref()],
                 compiler: getGoCommand(),
+                skipCompile: false,
+            };
+        }
+        case 'hs': {
+            return {
+                name: langName,
+                args: [...getHaskellArgsPref()],
+                compiler: getHaskellCommand(),
                 skipCompile: false,
             };
         }


### PR DESCRIPTION
I added support for running Haskell via the extension. The default compiler is `ghc`. Unfortunately, Haskell always saves the temporary object files next to the source file, so to avoid clutter I redirect them to `/tmp/ghc`.

![image](https://github.com/agrawal-d/cph/assets/12871757/2134637e-c824-4c8f-9de4-0731abc8e473)

Probably not a very popular language, but I wanted to use it, so I added it. Also, it is available on Codeforces and is a different paradigm, so it makes sense to have it, I guess.