### PR TITLE
Read chunked data from companion server

### DIFF
--- a/src/companion.ts
+++ b/src/companion.ts
@@ -98,12 +98,9 @@ export const setupCompanionServer = () => {
             const { headers } = req;
             let rawProblem = '';
 
-            req.on('readable', function () {
+            req.on('data', (chunk) => {
                 COMPANION_LOGGING && console.log('Companion server got data');
-                const tmp = req.read();
-                if (tmp && tmp != null && tmp.length > 0) {
-                    rawProblem += tmp;
-                }
+                rawProblem += chunk;
             });
             req.on('close', function () {
                 try {
@@ -112,7 +109,9 @@ export const setupCompanionServer = () => {
                     COMPANION_LOGGING &&
                         console.log('Companion server closed connection.');
                 } catch (e) {
-                    // Ignore
+                    vscode.window.showErrorMessage(
+                        `Error parsing problem from companion "${e}"`,
+                    );
                 }
             });
             res.write(JSON.stringify(savedResponse));


### PR DESCRIPTION
### Problem Description

While developing a new parser for [competitive companion](https://github.com/jmerle/competitive-companion/), a strange bug occurred where some problems did not consistently get transferred. Thinking that the problem was with the parser, this was investigated first. However, all problems were successfully sent.

Other companion clients were able to receive the problems, so I investigated cph. When not ignoring the error, the `JSON.parse` was throwing `Error parsing problem from companion "SyntaxError: Incomplete string in JSON at position 64975"`.

This indicated that the buffer of the `read()` call was full and only a single chunk of data was being read. This only appeared on problems where the parsed test data was large enough to trigger this.

### Solution

Changing the listener to `data` and parsing `chunk` now works for all submitted problems and contests.