### PR TITLE
Updated codeforces submit compiler option

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
                         "GNU G++14 6.4.0",
                         "GNU G++11 5.1.0",
                         "GNU G++17 9.2.0 (64 bit, msys 2)",
-                        "GNU G++20 11.2.0 (64 bit, winlibs)",
+                        "GNU G++20 13.2 (64 bit, winlibs)",
                         "Microsoft Visual C++ 2017",
                         "Microsoft Visual C++ 2010",
                         "Clang++17 Diagnostics"

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export default {
         'GNU G++14 6.4.0': 50,
         'GNU G++11 5.1.0': 42,
         'GNU G++17 9.2.0 (64 bit, msys 2)': 61,
-        'GNU G++20 11.2.0 (64 bit, winlibs)': 73,
+        'GNU G++20 13.2 (64 bit, winlibs)': 73,
         'Microsoft Visual C++ 2017': 59,
         'Microsoft Visual C++ 2010': 2,
         'Clang++17 Diagnostics': 52,


### PR DESCRIPTION
The compiler option for codeforces G++20 11.2.0 is updated to G++20 13.2 as the latest update from codeforces.