### PR TITLE
Add support for m1/m2/m3.codeforces.com

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ export const isValidLanguage = (srcPath: string): boolean => {
 };
 
 export const isCodeforcesUrl = (url: URL): boolean => {
-    return url.hostname === 'codeforces.com';
+    return url.hostname.includes('codeforces.com');
 };
 
 export const ocAppend = (string: string) => {


### PR DESCRIPTION
Currently use short codeforces name only works with https://codeforces.com/

This PR adds short name support for https://m1.codeforces.com/ which is a lightweight version of codeforces people use during contest

# Before

![image](https://github.com/agrawal-d/cph/assets/56817415/dc1e61ef-6e73-41cd-b4d1-ecbcc42030c6)

# After

![image](https://github.com/agrawal-d/cph/assets/56817415/5f5a45cf-7aa2-4d4b-a2c4-1e09e7964809)
