### PR TITLE
Update config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export default {
         'GNU G++14 6.4.0': 50,
         'GNU G++11 5.1.0': 42,
         'GNU G++17 9.2.0 (64 bit, msys 2)': 61,
-        'GNU G++20 13.2 (64 bit, winlibs)': 73,
+        'GNU G++20 13.2 (64 bit, winlibs)': 89,
         'Microsoft Visual C++ 2017': 59,
         'Microsoft Visual C++ 2010': 2,
         'Clang++17 Diagnostics': 52,


### PR DESCRIPTION
The value corresponding to new GNU G++20 13.2 (64 bit, winlibs) has been updated to 89 from previous value 73, that's why the extension was failing to submit to new G++20 compiler. 

The proof can be seen on the source page of submit section: https://codeforces.com/problemset/submit

![image](https://github.com/agrawal-d/cph/assets/97392398/b1911f70-03a9-47a0-b828-17d550a488d8)

Thank you for this useful extension.