### PR TITLE
Add "workspace mode" feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
                     "default": "",
                     "description": "Location where generated .tcs and .bin files will be saved. Leave empty to save the file in the source file directory. Use this to clean up your folders."
                 },
+                "cph.general.workspaceMode": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If enabled, the generated file location will be `workspaceRoot/.cph` . If disabled (default), the save location will follow `cph.general.saveLocation`"
+                },
                 "cph.general.timeOut": {
                     "type": "number",
                     "default": 3000,

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
                     "default": false,
                     "description": "If enabled, the generated file location will be `workspaceRoot/.cph` . If disabled (default), the save location will follow `cph.general.saveLocation`"
                 },
+                "cph.general.autoRefactor": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Automatically change the file path in the .prob file to new file path when the file is renamed or moved. Works only in workspace mode."
+                },
                 "cph.general.timeOut": {
                     "type": "number",
                     "default": 3000,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import {
     getSaveLocationPref,
     getHideStderrorWhenCompiledOK,
+    getWorkspaceModePref,
 } from './preferences';
 import * as vscode from 'vscode';
 import { getJudgeViewProvider } from './extension';
@@ -31,10 +32,13 @@ export const getBinSaveLocation = (srcPath: string): string => {
     }
     const ext = language.name == 'java' ? '*.class' : '.bin';
     const savePreference = getSaveLocationPref();
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
     const srcFileName = path.parse(srcPath).name;
     const binFileName = srcFileName + ext;
     const binDir = path.dirname(srcPath);
-    if (savePreference && savePreference !== '') {
+    if (getWorkspaceModePref() && workspaceFolder) {
+        return path.join(workspaceFolder, '.cph', binFileName);
+    } else if (savePreference && savePreference !== '') {
         return path.join(savePreference, binFileName);
     }
     return path.join(binDir, binFileName);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import JudgeViewProvider from './webview/JudgeView';
 import { getRetainWebviewContextPref } from './preferences';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import config from './config';
+import { editorRename } from './refactor';
 
 let judgeViewProvider: JudgeViewProvider;
 
@@ -93,6 +94,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.window.onDidChangeActiveTextEditor((e) => {
         editorChanged(e);
+    });
+
+    vscode.workspace.onDidRenameFiles((e) => {
+        editorRename(e);
     });
 
     vscode.window.onDidChangeVisibleTextEditors((editors) => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -56,6 +56,27 @@ export const getProblem = (srcPath: string): Problem | null => {
     }
 };
 
+/** Get the problem from the problem path instead of the source path */
+export const getProblemFromProbPath = (probPath: string): Problem | null => {
+    let problem: string;
+    try {
+        problem = fs.readFileSync(probPath).toString();
+    } catch (e) {
+        return null;
+    }
+    const parsedProblem = JSON.parse(problem);
+    const workspaceRoot = getWorkspaceRoot();
+
+    if (parsedProblem == null) return null;
+    if (workspaceRoot) {
+        parsedProblem.srcPath = path.resolve(
+            workspaceRoot,
+            parsedProblem.srcPath,
+        );
+    }
+    return parsedProblem;
+};
+
 /** Save the problem (metadata) */
 export const saveProblem = (srcPath: string, problem: Problem) => {
     const srcFolder = path.dirname(srcPath);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,14 +1,9 @@
 import path from 'path';
 import fs from 'fs';
 import { Problem } from './types';
-import { getSaveLocationPref, getWorkspaceModePref } from './preferences';
+import { getSaveLocationPref } from './preferences';
 import crypto from 'crypto';
-import { workspace } from 'vscode';
-
-const getWorkspaceRoot = () =>
-    getWorkspaceModePref()
-        ? workspace.workspaceFolders?.[0].uri.fsPath
-        : undefined;
+import { getWorkspaceRoot } from './utils';
 
 /**
  *  Get the location (file path) to save the generated problem file in. If save

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -20,7 +20,9 @@ export const getAutoShowJudgePref = (): boolean =>
     getPreference('general.autoShowJudge');
 
 export const getSaveLocationPref = (): string => {
-    const pref = getPreference('general.saveLocation');
+    const pref = getPreference('general.workspaceMode')
+        ? '' // If workspace mode is enabled, save location is ignored
+        : getPreference('general.saveLocation');
     const validSaveLocation = pref == '' || fs.existsSync(pref);
     if (!validSaveLocation) {
         vscode.window.showErrorMessage(
@@ -31,6 +33,9 @@ export const getSaveLocationPref = (): string => {
     }
     return pref;
 };
+
+export const getWorkspaceModePref = (): boolean =>
+    getPreference('general.workspaceMode');
 
 export const getHideStderrorWhenCompiledOK = (): boolean =>
     getPreference('general.hideStderrorWhenCompiledOK');

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -34,6 +34,9 @@ export const getSaveLocationPref = (): string => {
     return pref;
 };
 
+export const getAutoRefactorPref = (): boolean =>
+    getPreference('general.autoRefactor');
+
 export const getWorkspaceModePref = (): boolean =>
     getPreference('general.workspaceMode');
 

--- a/src/refactor.ts
+++ b/src/refactor.ts
@@ -1,19 +1,23 @@
 import * as vscode from 'vscode';
 import { getWorkspaceRoot } from './utils';
-import { getProblem, getProbSaveLocation, saveProblem } from './parser';
+import {
+    getProblemFromProbPath,
+    getProbSaveLocation,
+    saveProblem,
+} from './parser';
 import fs from 'fs';
 
 export const editorRename = (e: vscode.FileRenameEvent) => {
     const workspaceRoot = getWorkspaceRoot();
     if (!workspaceRoot) return;
     e.files.forEach((file) => {
-        const problem = getProblem(file.oldUri.fsPath);
+        const oldProblemPath = getProbSaveLocation(file.oldUri.fsPath);
+        const problem = getProblemFromProbPath(oldProblemPath);
         if (!problem) return;
         problem.srcPath = file.newUri.fsPath;
 
         saveProblem(file.newUri.fsPath, problem);
-        const oldProblem = getProbSaveLocation(file.oldUri.fsPath);
-        fs.unlinkSync(oldProblem);
+        fs.unlinkSync(oldProblemPath);
 
         console.log(
             'Renamed problem:',

--- a/src/refactor.ts
+++ b/src/refactor.ts
@@ -6,10 +6,10 @@ import {
     saveProblem,
 } from './parser';
 import fs from 'fs';
+import { getAutoRefactorPref } from './preferences';
 
 export const editorRename = (e: vscode.FileRenameEvent) => {
-    const workspaceRoot = getWorkspaceRoot();
-    if (!workspaceRoot) return;
+    if (!getAutoRefactorPref() || !getWorkspaceRoot()) return;
     e.files.forEach((file) => {
         const oldProblemPath = getProbSaveLocation(file.oldUri.fsPath);
         const problem = getProblemFromProbPath(oldProblemPath);

--- a/src/refactor.ts
+++ b/src/refactor.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { getWorkspaceRoot } from './utils';
+import { getProblem, getProbSaveLocation, saveProblem } from './parser';
+import fs from 'fs';
+
+export const editorRename = (e: vscode.FileRenameEvent) => {
+    const workspaceRoot = getWorkspaceRoot();
+    if (!workspaceRoot) return;
+    e.files.forEach((file) => {
+        const problem = getProblem(file.oldUri.fsPath);
+        if (!problem) return;
+        problem.srcPath = file.newUri.fsPath;
+
+        saveProblem(file.newUri.fsPath, problem);
+        const oldProblem = getProbSaveLocation(file.oldUri.fsPath);
+        fs.unlinkSync(oldProblem);
+
+        console.log(
+            'Renamed problem:',
+            file.oldUri.fsPath,
+            '->',
+            file.newUri.fsPath,
+        );
+    });
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 export type prefSection =
     | 'general.saveLocation'
     | 'general.workspaceMode'
+    | 'general.autoRefactor'
     | 'general.defaultLanguage'
     | 'general.timeOut'
     | 'general.hideStderrorWhenCompiledOK'

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 /** Valid name for a VS Code preference section for the extension */
 export type prefSection =
     | 'general.saveLocation'
+    | 'general.workspaceMode'
     | 'general.defaultLanguage'
     | 'general.timeOut'
     | 'general.hideStderrorWhenCompiledOK'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,9 +25,11 @@ import {
     getJsCommand,
     getGoCommand,
     getHaskellCommand,
+    getWorkspaceModePref,
 } from './preferences';
 import { Language, Problem } from './types';
 import telmetry from './telmetry';
+import { workspace } from 'vscode';
 
 const oc = vscode.window.createOutputChannel('cph');
 
@@ -198,3 +200,8 @@ export const getProblemForDocument = (
     const problem: Problem = JSON.parse(readFileSync(probPath).toString());
     return problem;
 };
+
+export const getWorkspaceRoot = () =>
+    getWorkspaceModePref()
+        ? workspace.workspaceFolders?.[0].uri.fsPath
+        : undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,10 @@
 import { spawn } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
 import { platform } from 'os';
 import path from 'path';
 import * as vscode from 'vscode';
 
 import config from './config';
-import { getProbSaveLocation } from './parser';
+import { getProblemFromProbPath, getProbSaveLocation } from './parser';
 import {
     getCArgsPref,
     getCppArgsPref,
@@ -194,11 +193,8 @@ export const getProblemForDocument = (
 
     const srcPath = document.fileName;
     const probPath = getProbSaveLocation(srcPath);
-    if (!existsSync(probPath)) {
-        return undefined;
-    }
-    const problem: Problem = JSON.parse(readFileSync(probPath).toString());
-    return problem;
+    const problem = getProblemFromProbPath(probPath);
+    return problem || undefined;
 };
 
 export const getWorkspaceRoot = () =>

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
-import { getProbSaveLocation } from '../parser';
-import { existsSync, readFileSync } from 'fs';
-import { Problem } from '../types';
+import { getProblemFromProbPath, getProbSaveLocation } from '../parser';
 import { getJudgeViewProvider } from '../extension';
 import { getProblemForDocument } from '../utils';
 import { getAutoShowJudgePref } from '../preferences';
@@ -61,12 +59,8 @@ export const editorClosed = (e: vscode.TextDocument) => {
     console.log('Closed editor:', e.uri.fsPath);
     const srcPath = e.uri.fsPath;
     const probPath = getProbSaveLocation(srcPath);
-
-    if (!existsSync(probPath)) {
-        return;
-    }
-
-    const problem: Problem = JSON.parse(readFileSync(probPath).toString());
+    const problem = getProblemFromProbPath(probPath);
+    if (!problem) return;
 
     if (getJudgeViewProvider().problemPath === problem.srcPath) {
         getJudgeViewProvider().extensionToJudgeViewMessage({


### PR DESCRIPTION
If `workspaceMode` is enabled, the following things will be applied:

- `.prob` files and bin will be saved at `workspaceRoot/.cph`
- The problem file's `srcPath` changes to relative path of current workspace 
- If `autoRefactor` is on, when moving and renaming files, the `srcPath` in problem file will also get changed

Since I use git to sync the code across computers, so these changes are essential for me. I think it can also help on moving code folder around and managing the code.