### PR TITLE
Add stdout of compiler to OutputChannel

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -153,6 +153,10 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
         }
         let error = '';
 
+        compiler.stdout.on('data', (data) => {
+            error += data;
+        });
+
         compiler.stderr.on('data', (data) => {
             error += data;
         });


### PR DESCRIPTION
Some compilers (such as `MSVC`) will output logs to both `stderr` and `stdout`. Showing `stdout` could be helpful when troubleshooting.

```pwsh
PS C:\> cl.exe test.cpp /Fe: test.bin -D DEBUG -D CPH 1>stdout.txt 2> stderr.txt      


PS C:\> cat .\stderr.txt                       
Microsoft (R) C/C++ Optimizing Compiler Version 19.41.34120 for x64
Copyright (C) Microsoft Corporation. All rights reserved.


PS C:\> cat .\stdout.txt
test.cpp
c:\test.cpp: fatal error C1041: Unable to open program database "C:\Program Files\Microsoft VS Code\vc140.pdb"; if you want to write multiple CL.EXE to the same .PDB file, use /FS.
```