### PR TITLE
Add support for gym problems

### DIFF
--- a/src/submit.ts
+++ b/src/submit.ts
@@ -88,16 +88,18 @@ export const submitToCodeForces = async () => {
 
 /** Get the problem name ( like 144C ) for a given Codeforces URL string. */
 export const getProblemName = (problemUrl: string): string => {
-    const parts = problemUrl.split('/');
-    let problemName: string;
+    const regexPatterns = [
+        /\/contest\/(\d+)\/problem\/(\w+)/,
+        /\/problemset\/problem\/(\d+)\/(\w+)/,
+        /\/gym\/(\d+)\/problem\/(\w+)/,
+    ];
 
-    if (parts.find((x) => x == 'contest')) {
-        // Url is like https://codeforces.com/contest/1398/problem/C
-        problemName = parts[parts.length - 3] + parts[parts.length - 1];
-    } else {
-        // Url is like https://codeforces.com/problemset/problem/1344/F
-        problemName = parts[parts.length - 2] + parts[parts.length - 1];
+    for (const regex of regexPatterns) {
+        const match = problemUrl.match(regex);
+        if (match) {
+            return match[1] + match[2];
+        }
     }
 
-    return problemName;
+    return '';
 };


### PR DESCRIPTION
This PR adds short name support for gym problems (E.x. https://codeforces.com/gym/105540/problem/F)

It also changes the code to use regex instead of split, which fixes an issue when parsing a problem url with parameters (E.x. https://codeforces.com/contest/2048/problem/I2?locale=en will end up with `2048I2?locale=en` instead of `2048I2`)

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/51e7c1bd-f898-415e-b574-d91b1d1bb569) | ![image](https://github.com/user-attachments/assets/11fb4e5f-e632-4b96-81d3-f0e5aa0b0b9b) |
| ![image](https://github.com/user-attachments/assets/c07c8709-bf97-409c-9316-f92299b26256) | ![image](https://github.com/user-attachments/assets/9b2ca5b9-8a8b-4846-a221-564b9f27571a) |