### PR TITLE
Update the SaveLocation in Global Settings.

### DIFF
--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -12,8 +12,12 @@ const getPreference = (section: prefSection): any => {
     return ret;
 };
 
-export const updatePreference = (section: prefSection, value: any) => {
-    return workspace.getConfiguration('cph').update(section, value);
+export const updatePreference = (
+    section: prefSection,
+    value: any,
+    target: vscode.ConfigurationTarget,
+) => {
+    return workspace.getConfiguration('cph').update(section, value, target);
 };
 
 export const getAutoShowJudgePref = (): boolean =>
@@ -26,7 +30,11 @@ export const getSaveLocationPref = (): string => {
         vscode.window.showErrorMessage(
             `Invalid save location, reverting to default. path not exists: ${pref}`,
         );
-        updatePreference('general.saveLocation', '');
+        updatePreference(
+            'general.saveLocation',
+            '',
+            vscode.ConfigurationTarget.Global,
+        );
         return '';
     }
     return pref;


### PR DESCRIPTION
If the user had an invalid path in the `saveLocation`, the path was updated in the workspace, but not the Global settings. This caused the creation and update of the `.vscode/settings.json` file in every workspace regardless if the extension was used or not. This fix adds a parameter that tells the vscode API to update the Global settings directly if the path is invalid.