### PR TITLE
Fix Duplicate ID, Add Per-Problem Time Limit and Custom Answer Comparison

### DIFF
--- a/src/companion.ts
+++ b/src/companion.ts
@@ -213,9 +213,10 @@ const handleNewProblem = async (problem: Problem) => {
 
     // Add fields absent in competitive companion.
     problem.srcPath = srcPath;
-    problem.tests = problem.tests.map((testcase) => ({
+    problem.tests = problem.tests.map((testcase, index) => ({
         ...testcase,
-        id: randomId(),
+        // Pass in index to avoid generating duplicate id
+        id: randomId(index),
     }));
     if (!existsSync(srcPath)) {
         writeFileSync(srcPath, '');

--- a/src/runTestCases.ts
+++ b/src/runTestCases.ts
@@ -64,7 +64,7 @@ const createLocalProblem = async (editor: vscode.TextEditor) => {
         url: srcPath,
         tests: [
             {
-                id: randomId(),
+                id: randomId(null),
                 input: '',
                 output: '',
             },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,7 +163,7 @@ export const ocHide = () => {
 };
 
 export const randomId = (index: number | null) => {
-    if (index) {
+    if (index !== null) {
         return Math.floor(Date.now() + index);
     } else {
         return Math.floor(Date.now() + Math.random() * 100);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,7 +162,13 @@ export const ocHide = () => {
     oc.hide();
 };
 
-export const randomId = () => Math.floor(Date.now() + Math.random() * 100);
+export const randomId = (index: number | null) => {
+    if (index) {
+        return Math.floor(Date.now() + index);
+    } else {
+        return Math.floor(Date.now() + Math.random() * 100);
+    }
+};
 
 /**
  * Check if file is supported. If not, shows an error dialog. Returns true if


### PR DESCRIPTION
Hello everyone! In this PR, I have fixed an issue that I encountered multiple times and added two useful features.

1. **ID duplication causing infinite running**: The original implementation used a random number in the range [1, 100] added to the timestamp as the ID. However, after calculation, it can be determined that if a problem with 4 examples is added by the companion, the probability of an error occurring will exceed 50% after just 8 problems. This will lead to an unending display of "running," which I have encountered many times.

2. **Adding a per-problem time limit**: Some problems have longer time limits, and it is not convenient to change the timeout setting in the preferences. Therefore, I added the option to modify it near "Set `ONLINE_JUDGE`".

3. **Different comparison methods**: Some problems involve floating-point comparison and Yes/No comparison, but this plugin can only perform text comparison, which is not very convenient. Therefore, I added an option to choose different precision floating-point comparisons and case-insensitive Yes/No comparisons.

Im sure I have passed the tests mentioned in `dev-guide.md`, hoping this work can be a helpful addition to the plugin.

![image](https://github.com/user-attachments/assets/b61e8eba-07d3-4240-98fb-b9dbc8972b9f)

