### PR TITLE
Added the support for .cc and .cxx file extensions and fixed a minor issue in the dev-guide

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -66,7 +66,7 @@ We recommend installing `Prettier` and `ESLint` VS Code extensions. Before
 commiting, make sure you are passing the following tests:
 
 -   ESLint lint: `npm run lint`.
--   Jest unit tests: `npm run jest`.
+-   Jest unit tests: `npm run test`.
 -   Typescript compilation: `npm run test-compile`.
 -   Pre-publish bundling: `npm run vscode:prepublish`.
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -69,7 +69,9 @@ const getFlags = (language: Language, srcPath: string): string[] => {
     if (args[0] === '') args = [];
     let ret: string[];
     switch (language.name) {
-        case 'cpp': {
+        case 'cpp':
+        case 'cc':
+        case 'cxx': {
             ret = [
                 srcPath,
                 getCppOutputArgPref(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ export default {
     extensions: {
         c: 'c',
         cpp: 'cpp',
+        cc: 'cpp',
+        cxx: 'cpp',
         csharp: 'cs',
         python: 'py',
         ruby: 'rb',
@@ -64,6 +66,8 @@ export default {
     supportedExtensions: [
         'py',
         'cpp',
+        'cc',
+        'cxx',
         'rs',
         'c',
         'java',

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -142,7 +142,9 @@ export const getLanguageId = (srcPath: string): number => {
     const extension = path.extname(srcPath);
     let compiler = null;
     switch (extension) {
-        case '.cpp': {
+        case '.cpp':
+        case '.cc':
+        case '.cxx': {
             compiler = getPreference('language.cpp.SubmissionCompiler');
             break;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export type LangNames =
     | 'ruby'
     | 'c'
     | 'cpp'
+    | 'cc'
+    | 'cxx'
     | 'rust'
     | 'java'
     | 'js'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,9 @@ export const getLanguage = (srcPath: string): Language => {
     }
 
     switch (langName) {
-        case 'cpp': {
+        case 'cpp':
+        case 'cc':
+        case 'cxx': {
             return {
                 name: langName,
                 args: [...getCppArgsPref()],


### PR DESCRIPTION
Hello! In this PR, I added support for the .cc and .cxx file extensions, as they are relatively common C++ source code file extensions.

In addition, I found an error in the `npm run jest` command when running the test and made corresponding corrections.

I've tested the compiled vsix plugin after modification on my Windows 11 and  on Ubuntu 24.04 LTS and everything is as expected.

Thank you very much for reading this pull request. Please let me know if anything else is required.