### PR TITLE
add short ID support for luogu and atcoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -346,6 +346,16 @@
                     "default": false,
                     "description": "Use a short ID for problem file generated ( like 144C ) instead of the complete problem name for codeforces problems"
                 },
+                "cph.general.useShortLuoguName": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use a short ID for problem file generated ( like P1145 / U123456 ) instead of the complete problem name for luogu problems"
+                },
+                "cph.general.useShortAtCoderName": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use a short ID for problem file generated ( like abc123a ) instead of the complete problem name for atcoder problems"
+                },
                 "cph.general.retainWebviewContext": {
                     "type": "boolean",
                     "default": false,

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -5,11 +5,13 @@ import { saveProblem } from './parser';
 import * as vscode from 'vscode';
 import path from 'path';
 import { writeFileSync, readFileSync, existsSync } from 'fs';
-import { isCodeforcesUrl, randomId } from './utils';
+import { isCodeforcesUrl, isLuoguUrl, isAtCoderUrl, randomId } from './utils';
 import {
     getDefaultLangPref,
     getLanguageId,
     useShortCodeForcesName,
+    useShortLuoguName,
+    useShortAtCoderName,
     getMenuChoices,
     getDefaultLanguageTemplateFileLocation,
 } from './preferences';
@@ -147,6 +149,16 @@ export const setupCompanionServer = () => {
 export const getProblemFileName = (problem: Problem, ext: string) => {
     if (isCodeforcesUrl(new URL(problem.url)) && useShortCodeForcesName()) {
         return `${getProblemName(problem.url)}.${ext}`;
+    } else if (isLuoguUrl(new URL(problem.url)) && useShortLuoguName()) {
+        // Url is like https://www.luogu.com.cn/problem/P1000
+        const pattern = /problem\/(\w+)/;
+        const match = problem.url.match(pattern);
+        return `${match?.[1] ?? ''}.${ext}`;
+    } else if (isAtCoderUrl(new URL(problem.url)) && useShortAtCoderName()) {
+        // Url is like https://atcoder.jp/contests/abc311/tasks/abc311_a
+        const pattern = /tasks\/(\w+)_(\w+)/;
+        const match = problem.url.match(pattern);
+        return `${match?.[1] ?? ''}${match?.[2] ?? ''}.${ext}`;
     } else {
         globalThis.logger.log(
             isCodeforcesUrl(new URL(problem.url)),

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -105,6 +105,12 @@ export const getDefaultLangPref = (): string | null => {
 export const useShortCodeForcesName = (): boolean => {
     return getPreference('general.useShortCodeForcesName');
 };
+export const useShortLuoguName = (): boolean => {
+    return getPreference('general.useShortLuoguName');
+};
+export const useShortAtCoderName = (): boolean => {
+    return getPreference('general.useShortAtCoderName');
+};
 export const getDefaultLanguageTemplateFileLocation = (): string | null => {
     const pref = getPreference('general.defaultLanguageTemplateFileLocation');
     if (pref === '') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type prefSection =
     | 'general.ignoreSTDERROR'
     | 'general.firstTime'
     | 'general.useShortCodeForcesName'
+    | 'general.useShortLuoguName'
+    | 'general.useShortAtCoderName'
     | 'general.menuChoices'
     | 'language.c.Args'
     | 'language.c.SubmissionCompiler'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,6 +145,12 @@ export const isValidLanguage = (srcPath: string): boolean => {
 export const isCodeforcesUrl = (url: URL): boolean => {
     return url.hostname.includes('codeforces.com');
 };
+export const isLuoguUrl = (url: URL): boolean => {
+    return url.hostname.indexOf('luogu.com.cn') !== -1;
+};
+export const isAtCoderUrl = (url: URL): boolean => {
+    return url.hostname === 'atcoder.jp';
+};
 
 export const ocAppend = (string: string) => {
     oc.append(string);


### PR DESCRIPTION
This PR implements short ID support for Luogu and AtCoder, enabling shorter file names when practising on these platforms.  


This feature has been mentioned by Issue #198, #528.