### PR TITLE
Allow to create folder and move .cph and code files to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
                 "cph.general.saveLocation": {
                     "type": "string",
                     "default": "",
-                    "description": "Location where generated .tcs and .bin files will be saved. Leave empty to save the file in the source file directory. Use this to clean up your folders."
+                    "description": "Directory where new problem source files and their .prob metadata will be saved. Leave empty to save in the workspace root for sources and alongside sources in .cph for metadata."
                 },
                 "cph.general.timeOut": {
                     "type": "number",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,5 +248,6 @@ export const getProblemForDocument = (
         return undefined;
     }
     const problem: Problem = JSON.parse(readFileSync(probPath).toString());
+    problem.srcPath = srcPath;
     return problem;
 };

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -67,6 +67,7 @@ export const editorClosed = (e: vscode.TextDocument) => {
     }
 
     const problem: Problem = JSON.parse(readFileSync(probPath).toString());
+    problem.srcPath = srcPath;
 
     if (getJudgeViewProvider().problemPath === problem.srcPath) {
         getJudgeViewProvider().extensionToJudgeViewMessage({


### PR DESCRIPTION
Now setting `Cph › General: Save Location` will also move .cph files into that folder. And .prob metadata now supports relative paths.

Relates to: #493 #570