### PR TITLE
Enhancement based on my personal view

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,15 @@
     "files.associations": {
         "iostream": "cpp"
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "[typescript]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "never"
+        }
+    },
+    "[typescriptreact]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "never"
+        }
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "competitive-programming-helper",
-    "version": "2079.0.0",
+    "version": "2080.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "competitive-programming-helper",
-            "version": "2079.0.0",
+            "version": "2080.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "competitive-programming-helper",
-    "version": "2077.0.0",
+    "version": "2078.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "competitive-programming-helper",
-            "version": "2077.0.0",
+            "version": "2078.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "competitive-programming-helper",
-    "version": "2078.0.0",
+    "version": "2079.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "competitive-programming-helper",
-            "version": "2078.0.0",
+            "version": "2079.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "competitive-programming-helper",
-    "version": "2080.0.0",
+    "version": "2081.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "competitive-programming-helper",
-            "version": "2080.0.0",
+            "version": "2081.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "icon": "icon.png",
     "publisher": "DivyanshuAgrawal",
-    "version": "2079.0.0",
+    "version": "2080.0.0",
     "engines": {
         "vscode": "^1.52.0"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "icon": "icon.png",
     "publisher": "DivyanshuAgrawal",
-    "version": "2077.0.0",
+    "version": "2078.0.0",
     "engines": {
         "vscode": "^1.52.0"
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
                 "cph.general.saveLocation": {
                     "type": "string",
                     "default": "",
-                    "description": "Location where generated .tcs and .bin files will be saved. Leave empty to save the file in the source file directory. Use this to clean up your folders."
+                    "description": "Directory where new problem source files and their .prob metadata will be saved. Leave empty to save in the workspace root for sources and alongside sources in .cph for metadata."
                 },
                 "cph.general.timeOut": {
                     "type": "number",

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
                 },
                 "cph.general.retainWebviewContext": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Keep the webview active even when it's hidden. May improve performance but may cause some rendering issues."
                 },
                 "cph.general.defaultLanguageTemplateFileLocation": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
                 "cph.general.saveLocation": {
                     "type": "string",
                     "default": "",
-                    "description": "Directory where new problem source files and their .prob metadata will be saved. Leave empty to save in the workspace root for sources and alongside sources in .cph for metadata."
+                    "description": "Directory where new problem source files and their .prob metadata will be saved. Supports the ${group} placeholder (e.g. '${group}/'), which is replaced with the problem's group. Leave empty to save in the workspace root for sources and alongside sources in .cph for metadata."
                 },
                 "cph.general.timeOut": {
                     "type": "number",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "icon": "icon.png",
     "publisher": "DivyanshuAgrawal",
-    "version": "2080.0.0",
+    "version": "2081.0.0",
     "engines": {
         "vscode": "^1.52.0"
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-or-later",
     "icon": "icon.png",
     "publisher": "DivyanshuAgrawal",
-    "version": "2078.0.0",
+    "version": "2079.0.0",
     "engines": {
         "vscode": "^1.52.0"
     },

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -222,7 +222,12 @@ const handleNewProblem = async (problem: Problem) => {
         problem.name = splitUrl[splitUrl.length - 1];
     }
     const problemFileName = getProblemFileName(problem, extn);
-    const configuredSaveDir = getSaveLocationPref();
+    let configuredSaveDir = getSaveLocationPref();
+    if (configuredSaveDir && configuredSaveDir.includes('${group}')) {
+        const groupKey = (problem.group || '').trim();
+        const replacement = groupKey === '' ? '' : groupKey;
+        configuredSaveDir = configuredSaveDir.replace(/\$\{group\}/g, replacement);
+    }
     const targetDir =
         configuredSaveDir && configuredSaveDir !== ''
             ? configuredSaveDir

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -248,7 +248,17 @@ const handleNewProblem = async (problem: Problem) => {
         writeFileSync(srcPath, '');
     }
     saveProblem(srcPath, problem);
-    const doc = await vscode.workspace.openTextDocument(srcPath);
+    // Avoid redundant openTextDocument if already open
+    const visibleEditor = vscode.window.visibleTextEditors.find(
+        (e) => e.document.fileName === srcPath,
+    );
+    const existingDoc =
+        visibleEditor?.document ||
+        vscode.workspace.textDocuments.find((d) => d.fileName === srcPath);
+    const doc =
+        existingDoc !== undefined
+            ? existingDoc
+            : await vscode.workspace.openTextDocument(srcPath);
 
     if (defaultLanguage) {
         const templateLocation = getDefaultLanguageTemplateFileLocation();

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -226,7 +226,10 @@ const handleNewProblem = async (problem: Problem) => {
     if (configuredSaveDir && configuredSaveDir.includes('${group}')) {
         const groupKey = (problem.group || '').trim();
         const replacement = groupKey === '' ? '' : groupKey;
-        configuredSaveDir = configuredSaveDir.replace(/\$\{group\}/g, replacement);
+        configuredSaveDir = configuredSaveDir.replace(
+            /\$\{group\}/g,
+            replacement,
+        );
     }
     const targetDir =
         configuredSaveDir && configuredSaveDir !== ''

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -51,7 +51,11 @@ export const getBinSaveLocation = (srcPath: string): string => {
     const srcFileName = path.parse(srcPath).name;
     const binFileName = toAsciiFilename(srcFileName) + ext;
     const binDir = path.dirname(srcPath);
-    if (savePreference && savePreference !== '' && !savePreference.includes('${')) {
+    if (
+        savePreference &&
+        savePreference !== '' &&
+        !savePreference.includes('${')
+    ) {
         return path.join(savePreference, binFileName);
     }
     return path.join(binDir, binFileName);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -51,7 +51,7 @@ export const getBinSaveLocation = (srcPath: string): string => {
     const srcFileName = path.parse(srcPath).name;
     const binFileName = toAsciiFilename(srcFileName) + ext;
     const binDir = path.dirname(srcPath);
-    if (savePreference && savePreference !== '') {
+    if (savePreference && savePreference !== '' && !savePreference.includes('${')) {
         return path.join(savePreference, binFileName);
     }
     return path.join(binDir, binFileName);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -55,12 +55,20 @@ export const findProbPath = (srcPath: string): string | null => {
             continue;
         }
         // Prioritize files that start with the source filename
-        const prioritized = [
-            ...files.filter((f) => f.startsWith(srcFileName)),
-            ...files.filter((f) => !f.startsWith(srcFileName)),
-        ];
+        const prioritized = [];
+        const nonPrioritized = [];
+        for (const file of files) {
+            const name = file.startsWith('.') ? file.slice(1) : file;
+            if (name.startsWith(srcFileName)) {
+                prioritized.push(file);
+            } else {
+                nonPrioritized.push(file);
+            }
+        }
 
-        for (const file of prioritized) {
+        const all = [...prioritized, ...nonPrioritized];
+
+        for (const file of all) {
             const fullProbPath = path.join(cphFolder, file);
             try {
                 const content = fs.readFileSync(fullProbPath).toString();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -127,7 +127,7 @@ export const saveProblem = (srcPath: string, problem: Problem) => {
             // Store path relative to parent of .cph folder when possible
             srcPath: path.relative(path.dirname(probDir), srcPath),
         };
-        fs.writeFileSync(probPath, JSON.stringify(problemToSave));
+        fs.writeFileSync(probPath, JSON.stringify(problemToSave, null, 2));
     } catch (err) {
         throw new Error(err as string);
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,20 +27,21 @@ export const findProbPath = (srcPath: string): string | null => {
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(
         vscode.Uri.file(srcPath),
     );
-    const workspaceRoot = workspaceFolder?.uri.fsPath ?? path.parse(srcFolder).root;
+    const workspaceRoot =
+        workspaceFolder?.uri.fsPath ?? path.parse(srcFolder).root;
 
     const ancestors: string[] = [];
     let currentDir = srcFolder;
     // Collect ancestor directories up to workspace root (inclusive)
-    while (true) {
+    let reachedRoot = false;
+    while (!reachedRoot) {
         ancestors.push(currentDir);
-        if (
+        reachedRoot =
             path.resolve(currentDir) === path.resolve(workspaceRoot) ||
-            path.dirname(currentDir) === currentDir
-        ) {
-            break;
+            path.dirname(currentDir) === currentDir;
+        if (!reachedRoot) {
+            currentDir = path.dirname(currentDir);
         }
-        currentDir = path.dirname(currentDir);
     }
 
     for (const dir of ancestors) {
@@ -84,7 +85,10 @@ export const findProbPath = (srcPath: string): string | null => {
                 } else {
                     resolvedRecorded = path.resolve(parentOfCph, recorded);
                 }
-                if (path.normalize(resolvedRecorded) === path.normalize(srcPath)) {
+                const samePath =
+                    path.normalize(resolvedRecorded) ===
+                    path.normalize(srcPath);
+                if (samePath) {
                     return fullProbPath;
                 }
             } catch (_e) {

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -40,8 +40,11 @@ export const getSaveLocationPref = (): string => {
     }
 
     try {
-        if (!fs.existsSync(resolved)) {
-            fs.mkdirSync(resolved, { recursive: true });
+        // Do not create directories if path contains template placeholders like ${group}
+        if (!resolved.includes('${')) {
+            if (!fs.existsSync(resolved)) {
+                fs.mkdirSync(resolved, { recursive: true });
+            }
         }
         return resolved;
     } catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,5 +248,6 @@ export const getProblemForDocument = (
         return undefined;
     }
     const problem: Problem = JSON.parse(readFileSync(probPath).toString());
+    problem.srcPath = srcPath;
     return problem;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import * as vscode from 'vscode';
 
 import config from './config';
-import { getProbSaveLocation } from './parser';
+import { findProbPath, getProbSaveLocation } from './parser';
 import {
     getCArgsPref,
     getCppArgsPref,
@@ -195,7 +195,7 @@ export const checkUnsupported = (srcPath: string): boolean => {
 /** Deletes the .prob problem file for a given source code path. */
 export const deleteProblemFile = async (srcPath: string) => {
     globalThis.reporter.sendTelemetryEvent(telmetry.DELETE_ALL_TESTCASES);
-    const probPath = getProbSaveLocation(srcPath);
+    const probPath = findProbPath(srcPath) ?? getProbSaveLocation(srcPath);
 
     globalThis.logger.log('Deleting problem file', probPath);
     try {
@@ -243,8 +243,8 @@ export const getProblemForDocument = (
     }
 
     const srcPath = document.fileName;
-    const probPath = getProbSaveLocation(srcPath);
-    if (!existsSync(probPath)) {
+    const probPath = findProbPath(srcPath);
+    if (!probPath || !existsSync(probPath)) {
         return undefined;
     }
     const problem: Problem = JSON.parse(readFileSync(probPath).toString());

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -6,7 +6,7 @@ import { VSToWebViewMessage, WebviewToVSEvent } from '../types';
 import { deleteProblemFile, getProblemForDocument } from '../utils';
 import { runSingleAndSave } from './processRunSingle';
 import runAllAndSave from './processRunAll';
-import runTestCases from '../runTestCases';
+import { createLocalProblem } from '../runTestCases';
 import {
     getAutoShowJudgePref,
     getRemoteServerAddressPref,
@@ -24,6 +24,10 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
 
     public isViewUninitialized() {
         return this._view === undefined;
+    }
+
+    public isOpen() {
+        return !!this._view && this._view.visible === true;
     }
 
     constructor(private readonly _extensionUri: vscode.Uri) {}
@@ -100,7 +104,7 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                     }
 
                     case 'create-local-problem': {
-                        runTestCases();
+                        createLocalProblem();
                         break;
                     }
 
@@ -169,7 +173,9 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
         if (
             message.command === 'new-problem' &&
             message.problem !== undefined &&
-            getAutoShowJudgePref()
+            getAutoShowJudgePref() &&
+            vscode.window.activeTextEditor?.document.fileName ===
+                message.problem.srcPath
         ) {
             this.focus();
         }

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Problem } from '../types';
 import { getJudgeViewProvider } from '../extension';
 import { getProblemForDocument } from '../utils';
-import { getAutoShowJudgePref } from '../preferences';
+// import { getAutoShowJudgePref } from '../preferences';
 import { setOnlineJudgeEnv } from '../compiler';
 
 /**

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -67,6 +67,7 @@ export const editorClosed = (e: vscode.TextDocument) => {
     }
 
     const problem: Problem = JSON.parse(readFileSync(probPath).toString());
+    problem.srcPath = srcPath;
 
     if (getJudgeViewProvider().problemPath === problem.srcPath) {
         getJudgeViewProvider().extensionToJudgeViewMessage({

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -101,6 +101,7 @@ function Judge(props: {
     const total = cases.length;
 
     useEffect(() => {
+        if (!window.showLiveUserCount) return;
         const updateLiveUserCount = (): void => {
             getLiveUserCount().then((count) => setLiveUserCount(count));
         };

--- a/src/webview/frontend/CaseView.tsx
+++ b/src/webview/frontend/CaseView.tsx
@@ -1,6 +1,5 @@
 import { Case, VSToWebViewMessage } from '../../types';
 import { useState, createRef, useEffect } from 'react';
-import TextareaAutosize from 'react-textarea-autosize';
 import React from 'react';
 import { LinedTextarea } from './Lined';
 
@@ -23,13 +22,17 @@ export default function CaseView(props: {
         props.case.result?.pass === true,
     );
     const inputBox = createRef<HTMLTextAreaElement>();
-    const [externalHoverLine, setExternalHoverLine] = useState<number | null>(null);
+    const [externalHoverLine, setExternalHoverLine] = useState<number | null>(
+        null,
+    );
 
     const inputGutterLabel = (lineIdx: number, allLines: string[]): string => {
         const first = (allLines[0] ?? '').trim();
         const t = parseInt(first, 10);
         if (!Number.isFinite(t) || t <= 0) return String(lineIdx + 1);
-        const nonEmpty = allLines.filter((l, idx) => idx === 0 ? true : l.trim().length > 0);
+        const nonEmpty = allLines.filter((l, idx) =>
+            idx === 0 ? true : l.trim().length > 0,
+        );
         const totalNonEmpty = nonEmpty.length;
         // Try k = 1..10 to find a plausible grouping
         for (let k = 1; k <= 3; k++) {
@@ -45,8 +48,11 @@ export default function CaseView(props: {
         const first = (allLines[0] ?? '').trim();
         const t = parseInt(first, 10);
         if (!Number.isFinite(t) || t <= 0) return false;
-        const totalNonEmpty = allLines.filter((l, idx) => idx === 0 ? true : l.trim().length > 0).length;
-        for (let k = 1; k <= 3; k++) if (totalNonEmpty === t * k + 1) return true;
+        const totalNonEmpty = allLines.filter((l, idx) =>
+            idx === 0 ? true : l.trim().length > 0,
+        ).length;
+        for (let k = 1; k <= 3; k++)
+            if (totalNonEmpty === t * k + 1) return true;
         return false;
     };
 
@@ -141,49 +147,6 @@ export default function CaseView(props: {
     const caseClassName = 'case ' + (running ? 'running' : passFailText);
     const timeText = result?.timeOut ? 'Timed Out' : result?.time + 'ms';
 
-    const renderHighlighted = (
-        actual: string,
-        expected: string,
-    ): React.ReactNode[] => {
-        const nodes: React.ReactNode[] = [];
-        const tokenRegex = /\S+/gu;
-        const actualLines = actual.split('\n');
-        const expectedLines = expected.split('\n');
-        for (let lineIdx = 0; lineIdx < actualLines.length; lineIdx++) {
-            const aLine = actualLines[lineIdx];
-            const eLine = expectedLines[lineIdx] ?? '';
-            const expectedTokens = eLine.match(tokenRegex) || [];
-            const actualTokens = aLine.match(tokenRegex) || [];
-            const countMismatch = actualTokens.length !== expectedTokens.length;
-            let lastIndex = 0;
-            let tokenIndex = 0;
-            for (const match of aLine.matchAll(tokenRegex)) {
-                const start = match.index ?? 0;
-                const end = start + match[0].length;
-                if (start > lastIndex) nodes.push(aLine.slice(lastIndex, start));
-                const token = match[0];
-                const expectedToken = expectedTokens[tokenIndex];
-                const ok =
-                    !countMismatch &&
-                    expectedToken !== undefined &&
-                    expectedToken === token;
-                nodes.push(
-                    <span
-                        className={ok ? 'token-ok' : 'token-bad'}
-                        key={`l${lineIdx}t${start}`}
-                    >
-                        {token}
-                    </span>,
-                );
-                lastIndex = end;
-                tokenIndex++;
-            }
-            if (lastIndex < aLine.length) nodes.push(aLine.slice(lastIndex));
-            if (lineIdx < actualLines.length - 1) nodes.push('\n');
-        }
-        return nodes;
-    };
-
     return (
         <div className={caseClassName}>
             <div className="case-metadata">
@@ -272,7 +235,9 @@ export default function CaseView(props: {
                                 if (idx == null) return null;
                                 const lines = input.split('\n');
                                 const withHeader = hasTHeader(lines);
-                                const contentCount = withHeader ? Math.max(0, lines.length - 1) : lines.length;
+                                const contentCount = withHeader
+                                    ? Math.max(0, lines.length - 1)
+                                    : lines.length;
                                 if (idx >= contentCount) return null;
                                 return withHeader ? idx + 1 : idx;
                             })()}
@@ -280,7 +245,8 @@ export default function CaseView(props: {
                                 if (!hasTHeader(input.split('\n'))) {
                                     setExternalHoverLine(idx);
                                 } else {
-                                    if (idx == null || idx === 0) setExternalHoverLine(null);
+                                    if (idx == null || idx === 0)
+                                        setExternalHoverLine(null);
                                     else setExternalHoverLine((idx ?? 1) - 1);
                                 }
                             }}

--- a/src/webview/frontend/CaseView.tsx
+++ b/src/webview/frontend/CaseView.tsx
@@ -114,6 +114,49 @@ export default function CaseView(props: {
     const caseClassName = 'case ' + (running ? 'running' : passFailText);
     const timeText = result?.timeOut ? 'Timed Out' : result?.time + 'ms';
 
+    const renderHighlighted = (
+        actual: string,
+        expected: string,
+    ): React.ReactNode[] => {
+        const nodes: React.ReactNode[] = [];
+        const tokenRegex = /\S+/gu;
+        const actualLines = actual.split('\n');
+        const expectedLines = expected.split('\n');
+        for (let lineIdx = 0; lineIdx < actualLines.length; lineIdx++) {
+            const aLine = actualLines[lineIdx];
+            const eLine = expectedLines[lineIdx] ?? '';
+            const expectedTokens = eLine.match(tokenRegex) || [];
+            const actualTokens = aLine.match(tokenRegex) || [];
+            const countMismatch = actualTokens.length !== expectedTokens.length;
+            let lastIndex = 0;
+            let tokenIndex = 0;
+            for (const match of aLine.matchAll(tokenRegex)) {
+                const start = match.index ?? 0;
+                const end = start + match[0].length;
+                if (start > lastIndex) nodes.push(aLine.slice(lastIndex, start));
+                const token = match[0];
+                const expectedToken = expectedTokens[tokenIndex];
+                const ok =
+                    !countMismatch &&
+                    expectedToken !== undefined &&
+                    expectedToken === token;
+                nodes.push(
+                    <span
+                        className={ok ? 'token-ok' : 'token-bad'}
+                        key={`l${lineIdx}t${start}`}
+                    >
+                        {token}
+                    </span>,
+                );
+                lastIndex = end;
+                tokenIndex++;
+            }
+            if (lastIndex < aLine.length) nodes.push(aLine.slice(lastIndex));
+            if (lineIdx < actualLines.length - 1) nodes.push('\n');
+        }
+        return nodes;
+    };
+
     return (
         <div className={caseClassName}>
             <div className="case-metadata">
@@ -239,11 +282,12 @@ export default function CaseView(props: {
                                 Set
                             </div>
                             <>
-                                <TextareaAutosize
-                                    className="selectable received-textarea"
-                                    value={trunctateStdout(resultText)}
-                                    readOnly
-                                />
+                                <div className="selectable received-textarea pre-block">
+                                    {renderHighlighted(
+                                        trunctateStdout(resultText),
+                                        output,
+                                    )}
+                                </div>
                             </>
                         </div>
                     )}

--- a/src/webview/frontend/Lined.tsx
+++ b/src/webview/frontend/Lined.tsx
@@ -19,21 +19,42 @@ type LinedTextareaProps = {
 };
 
 export function LinedTextarea(props: LinedTextareaProps) {
-    const { value, onChange, className, autoFocus, inputRef, readOnly, externalHoverLine, onHoverLineChange, diffAgainst, gutterLabelForLine, hoverHighlightForLine } = props;
+    const {
+        value,
+        onChange,
+        className,
+        autoFocus,
+        inputRef,
+        readOnly,
+        externalHoverLine,
+        onHoverLineChange,
+        diffAgainst,
+        gutterLabelForLine,
+        hoverHighlightForLine,
+    } = props;
     const internalRef = useRef<HTMLTextAreaElement | null>(null);
     const gutterRef = useRef<HTMLDivElement | null>(null);
     const overlayInnerRef = useRef<HTMLDivElement | null>(null);
-    const gutterWheelHandlerRef = useRef<(e: WheelEvent) => void>();
+    //
     const [hoveredLine, setHoveredLine] = useState<number | null>(null);
     const [lineHeightPx, setLineHeightPx] = useState<number>(18);
-    const [overlayFontFamily, setOverlayFontFamily] = useState<string | undefined>(undefined);
-    const [overlayFontSize, setOverlayFontSize] = useState<string | undefined>(undefined);
-    const [overlayPadding, setOverlayPadding] = useState<{ top?: string; right?: string; bottom?: string; left?: string }>({});
+    const [overlayFontFamily, setOverlayFontFamily] = useState<
+        string | undefined
+    >(undefined);
+    const [overlayFontSize, setOverlayFontSize] = useState<string | undefined>(
+        undefined,
+    );
+    const [overlayPadding, setOverlayPadding] = useState<{
+        top?: string;
+        right?: string;
+        bottom?: string;
+        left?: string;
+    }>({});
 
     const lines = useMemo(() => Math.max(1, value.split('\n').length), [value]);
 
     useEffect(() => {
-        const ta = (inputRef?.current ?? internalRef.current);
+        const ta = inputRef?.current ?? internalRef.current;
         const gutter = gutterRef.current;
         if (!ta || !gutter) return;
         const onScroll = () => {
@@ -55,7 +76,7 @@ export function LinedTextarea(props: LinedTextareaProps) {
     }, [inputRef]);
 
     useEffect(() => {
-        const ta = (inputRef?.current ?? internalRef.current);
+        const ta = inputRef?.current ?? internalRef.current;
         if (!ta) return;
         const computed = window.getComputedStyle(ta);
         const lh = parseFloat(computed.lineHeight);
@@ -71,11 +92,14 @@ export function LinedTextarea(props: LinedTextareaProps) {
     }, [inputRef]);
 
     const handleMouseMove = (e: React.MouseEvent<HTMLTextAreaElement>) => {
-        const ta = (inputRef?.current ?? internalRef.current);
+        const ta = inputRef?.current ?? internalRef.current;
         if (!ta) return;
         const rect = ta.getBoundingClientRect();
         const localY = e.clientY - rect.top + ta.scrollTop;
-        const idx = Math.max(0, Math.min(lines - 1, Math.floor(localY / lineHeightPx)));
+        const idx = Math.max(
+            0,
+            Math.min(lines - 1, Math.floor(localY / lineHeightPx)),
+        );
         setHoveredLine(idx);
         onHoverLineChange?.(idx);
     };
@@ -92,9 +116,11 @@ export function LinedTextarea(props: LinedTextareaProps) {
         if (displayHoverLine == null) return null;
         const custom = hoverHighlightForLine?.(displayHoverLine, allLines);
         if (custom) return custom;
-        return { startLine: displayHoverLine, endLineExclusive: displayHoverLine + 1 };
+        return {
+            startLine: displayHoverLine,
+            endLineExclusive: displayHoverLine + 1,
+        };
     }, [displayHoverLine, hoverHighlightForLine, allLines]);
-    const minHeightPx = useMemo(() => lines * lineHeightPx, [lines, lineHeightPx]);
 
     const highlightedNodes = useMemo(() => {
         if (diffAgainst == null) return null;
@@ -113,12 +139,19 @@ export function LinedTextarea(props: LinedTextareaProps) {
             for (const match of aLine.matchAll(tokenRegex)) {
                 const start = match.index ?? 0;
                 const end = start + match[0].length;
-                if (start > lastIndex) nodes.push(aLine.slice(lastIndex, start));
+                if (start > lastIndex)
+                    nodes.push(aLine.slice(lastIndex, start));
                 const token = match[0];
                 const expectedToken = expectedTokens[tokenIndex];
-                const ok = !countMismatch && expectedToken !== undefined && expectedToken === token;
+                const ok =
+                    !countMismatch &&
+                    expectedToken !== undefined &&
+                    expectedToken === token;
                 nodes.push(
-                    <span className={ok ? 'token-ok' : 'token-bad'} key={`ol${lineIdx}t${start}`}>
+                    <span
+                        className={ok ? 'token-ok' : 'token-bad'}
+                        key={`ol${lineIdx}t${start}`}
+                    >
                         {token}
                     </span>,
                 );
@@ -152,14 +185,24 @@ export function LinedTextarea(props: LinedTextareaProps) {
                 style={{ paddingTop: 0, paddingBottom: overlayPadding.bottom }}
             >
                 {Array.from({ length: lines }, (_, i) => {
-                    const inRange = hoverRange && i >= hoverRange.startLine && i < hoverRange.endLineExclusive;
+                    const inRange =
+                        hoverRange &&
+                        i >= hoverRange.startLine &&
+                        i < hoverRange.endLineExclusive;
                     return (
                         <div
                             key={i}
-                            className={`lined-number${inRange ? ' is-hovered' : ''}`}
-                            style={{ height: `${lineHeightPx}px`, lineHeight: `${lineHeightPx}px` }}
+                            className={`lined-number${
+                                inRange ? ' is-hovered' : ''
+                            }`}
+                            style={{
+                                height: `${lineHeightPx}px`,
+                                lineHeight: `${lineHeightPx}px`,
+                            }}
                         >
-                            {gutterLabelForLine ? gutterLabelForLine(i, allLines) : (i + 1)}
+                            {gutterLabelForLine
+                                ? gutterLabelForLine(i, allLines)
+                                : i + 1}
                         </div>
                     );
                 })}
@@ -196,9 +239,11 @@ export function LinedTextarea(props: LinedTextareaProps) {
                     onMouseLeave={handleMouseLeave}
                     style={{
                         ...(bgStyle as TAStyle),
-                        backgroundColor: diffAgainst != null ? 'transparent' : undefined,
+                        backgroundColor:
+                            diffAgainst != null ? 'transparent' : undefined,
                         color: diffAgainst != null ? 'transparent' : undefined,
-                        caretColor: diffAgainst != null ? 'transparent' : undefined,
+                        caretColor:
+                            diffAgainst != null ? 'transparent' : undefined,
                         overflowY: 'auto',
                     }}
                 />

--- a/src/webview/frontend/Lined.tsx
+++ b/src/webview/frontend/Lined.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
+
+type LinedTextareaProps = {
+    value: string;
+    onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    className?: string;
+    autoFocus?: boolean;
+    inputRef?: React.RefObject<HTMLTextAreaElement>;
+    readOnly?: boolean;
+    externalHoverLine?: number | null;
+    onHoverLineChange?: (line: number | null) => void;
+    diffAgainst?: string;
+    gutterLabelForLine?: (lineIndex: number, allLines: string[]) => string;
+    hoverHighlightForLine?: (
+        lineIndex: number,
+        allLines: string[],
+    ) => { startLine: number; endLineExclusive: number } | null;
+};
+
+export function LinedTextarea(props: LinedTextareaProps) {
+    const { value, onChange, className, autoFocus, inputRef, readOnly, externalHoverLine, onHoverLineChange, diffAgainst, gutterLabelForLine, hoverHighlightForLine } = props;
+    const internalRef = useRef<HTMLTextAreaElement | null>(null);
+    const gutterRef = useRef<HTMLDivElement | null>(null);
+    const overlayInnerRef = useRef<HTMLDivElement | null>(null);
+    const gutterWheelHandlerRef = useRef<(e: WheelEvent) => void>();
+    const [hoveredLine, setHoveredLine] = useState<number | null>(null);
+    const [lineHeightPx, setLineHeightPx] = useState<number>(18);
+    const [overlayFontFamily, setOverlayFontFamily] = useState<string | undefined>(undefined);
+    const [overlayFontSize, setOverlayFontSize] = useState<string | undefined>(undefined);
+    const [overlayPadding, setOverlayPadding] = useState<{ top?: string; right?: string; bottom?: string; left?: string }>({});
+
+    const lines = useMemo(() => Math.max(1, value.split('\n').length), [value]);
+
+    useEffect(() => {
+        const ta = (inputRef?.current ?? internalRef.current);
+        const gutter = gutterRef.current;
+        if (!ta || !gutter) return;
+        const onScroll = () => {
+            if (gutter) gutter.scrollTop = ta.scrollTop;
+            if (overlayInnerRef.current) {
+                overlayInnerRef.current.style.transform = `translateY(${-ta.scrollTop}px)`;
+            }
+        };
+        ta.addEventListener('scroll', onScroll);
+        // Forward wheel events from gutter to textarea for unified scrolling
+        const onWheel = (e: WheelEvent) => {
+            ta.scrollTop += e.deltaY;
+        };
+        gutter.addEventListener('wheel', onWheel);
+        return () => {
+            ta.removeEventListener('scroll', onScroll);
+            gutter.removeEventListener('wheel', onWheel as EventListener);
+        };
+    }, [inputRef]);
+
+    useEffect(() => {
+        const ta = (inputRef?.current ?? internalRef.current);
+        if (!ta) return;
+        const computed = window.getComputedStyle(ta);
+        const lh = parseFloat(computed.lineHeight);
+        if (!Number.isNaN(lh)) setLineHeightPx(lh);
+        setOverlayFontFamily(computed.fontFamily);
+        setOverlayFontSize(computed.fontSize);
+        setOverlayPadding({
+            top: computed.paddingTop,
+            right: computed.paddingRight,
+            bottom: computed.paddingBottom,
+            left: computed.paddingLeft,
+        });
+    }, [inputRef]);
+
+    const handleMouseMove = (e: React.MouseEvent<HTMLTextAreaElement>) => {
+        const ta = (inputRef?.current ?? internalRef.current);
+        if (!ta) return;
+        const rect = ta.getBoundingClientRect();
+        const localY = e.clientY - rect.top + ta.scrollTop;
+        const idx = Math.max(0, Math.min(lines - 1, Math.floor(localY / lineHeightPx)));
+        setHoveredLine(idx);
+        onHoverLineChange?.(idx);
+    };
+
+    const handleMouseLeave = () => {
+        setHoveredLine(null);
+        onHoverLineChange?.(null);
+    };
+
+    type TAStyle = React.ComponentProps<typeof TextareaAutosize>['style'];
+    const displayHoverLine = externalHoverLine ?? hoveredLine;
+    const allLines = useMemo(() => value.split('\n'), [value]);
+    const hoverRange = useMemo(() => {
+        if (displayHoverLine == null) return null;
+        const custom = hoverHighlightForLine?.(displayHoverLine, allLines);
+        if (custom) return custom;
+        return { startLine: displayHoverLine, endLineExclusive: displayHoverLine + 1 };
+    }, [displayHoverLine, hoverHighlightForLine, allLines]);
+    const minHeightPx = useMemo(() => lines * lineHeightPx, [lines, lineHeightPx]);
+
+    const highlightedNodes = useMemo(() => {
+        if (diffAgainst == null) return null;
+        const nodes: React.ReactNode[] = [];
+        const tokenRegex = /\S+/gu;
+        const actualLines = value.split('\n');
+        const expectedLines = diffAgainst.split('\n');
+        for (let lineIdx = 0; lineIdx < actualLines.length; lineIdx++) {
+            const aLine = actualLines[lineIdx];
+            const eLine = expectedLines[lineIdx] ?? '';
+            const expectedTokens = eLine.match(tokenRegex) || [];
+            const actualTokens = aLine.match(tokenRegex) || [];
+            const countMismatch = actualTokens.length !== expectedTokens.length;
+            let lastIndex = 0;
+            let tokenIndex = 0;
+            for (const match of aLine.matchAll(tokenRegex)) {
+                const start = match.index ?? 0;
+                const end = start + match[0].length;
+                if (start > lastIndex) nodes.push(aLine.slice(lastIndex, start));
+                const token = match[0];
+                const expectedToken = expectedTokens[tokenIndex];
+                const ok = !countMismatch && expectedToken !== undefined && expectedToken === token;
+                nodes.push(
+                    <span className={ok ? 'token-ok' : 'token-bad'} key={`ol${lineIdx}t${start}`}>
+                        {token}
+                    </span>,
+                );
+                lastIndex = end;
+                tokenIndex++;
+            }
+            if (lastIndex < aLine.length) nodes.push(aLine.slice(lastIndex));
+            if (lineIdx < actualLines.length - 1) nodes.push('\n');
+        }
+        return nodes;
+    }, [value, diffAgainst]);
+    const bgStyle = useMemo(() => {
+        if (!hoverRange) return {} as TAStyle;
+        const top = hoverRange.startLine * lineHeightPx;
+        const bottom = hoverRange.endLineExclusive * lineHeightPx;
+        const from = `${Math.max(0, top)}px`;
+        const to = `${bottom}px`;
+        const color = 'rgba(200, 200, 200, 0.08)';
+        return {
+            backgroundImage: `linear-gradient(to bottom, transparent ${from}, ${color} ${from}, ${color} ${to}, transparent ${to})`,
+            backgroundAttachment: 'local',
+        } as TAStyle;
+    }, [hoverRange, lineHeightPx]);
+
+    return (
+        <div className="lined-container">
+            <div
+                className="lined-gutter"
+                ref={gutterRef}
+                aria-hidden="true"
+                style={{ paddingTop: 0, paddingBottom: overlayPadding.bottom }}
+            >
+                {Array.from({ length: lines }, (_, i) => {
+                    const inRange = hoverRange && i >= hoverRange.startLine && i < hoverRange.endLineExclusive;
+                    return (
+                        <div
+                            key={i}
+                            className={`lined-number${inRange ? ' is-hovered' : ''}`}
+                            style={{ height: `${lineHeightPx}px`, lineHeight: `${lineHeightPx}px` }}
+                        >
+                            {gutterLabelForLine ? gutterLabelForLine(i, allLines) : (i + 1)}
+                        </div>
+                    );
+                })}
+            </div>
+            <div className="lined-content">
+                {diffAgainst != null && (
+                    <div className="lined-overlay" aria-hidden="true">
+                        <div
+                            className={`lined-overlay-inner ${className ?? ''}`}
+                            ref={overlayInnerRef}
+                            style={{
+                                ...(bgStyle as React.CSSProperties),
+                                lineHeight: `${lineHeightPx}px`,
+                                fontFamily: overlayFontFamily,
+                                fontSize: overlayFontSize,
+                                paddingTop: overlayPadding.top,
+                                paddingRight: overlayPadding.right,
+                                paddingBottom: overlayPadding.bottom,
+                                paddingLeft: overlayPadding.left,
+                            }}
+                        >
+                            {highlightedNodes}
+                        </div>
+                    </div>
+                )}
+                <TextareaAutosize
+                    className={className}
+                    onChange={onChange}
+                    value={value}
+                    ref={inputRef ?? internalRef}
+                    autoFocus={autoFocus}
+                    readOnly={readOnly}
+                    onMouseMove={handleMouseMove}
+                    onMouseLeave={handleMouseLeave}
+                    style={{
+                        ...(bgStyle as TAStyle),
+                        backgroundColor: diffAgainst != null ? 'transparent' : undefined,
+                        color: diffAgainst != null ? 'transparent' : undefined,
+                        caretColor: diffAgainst != null ? 'transparent' : undefined,
+                        overflowY: 'auto',
+                    }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/webview/frontend/app.css
+++ b/src/webview/frontend/app.css
@@ -17,7 +17,7 @@
     scrollbar-width: thin;
 }
 
-.selectable {
+.selectable * {
     -webkit-touch-callout: text;
     /* iOS Safari */
     -webkit-user-select: text;
@@ -100,11 +100,9 @@ body {
 }
 
 .case {
-    background: linear-gradient(
-        to right,
-        rgba(0, 0, 0, 0.1),
-        rgba(87, 87, 87, 0.2)
-    );
+    background: linear-gradient(to right,
+            rgba(0, 0, 0, 0.1),
+            rgba(87, 87, 87, 0.2));
     border-bottom: 1px solid rgba(78, 78, 78, 0.3);
     border-top: 1px solid rgba(22, 22, 22, 0.3);
     padding: 8px;
@@ -192,6 +190,17 @@ textarea:active {
     background: black;
     outline: none !important;
     border: 1px solid #3393cc;
+}
+
+.pre-block {
+    white-space: pre-wrap;
+    background: var(--input-background);
+    color: bisque;
+    width: 100%;
+    max-height: 250px !important;
+    overflow-y: auto;
+    border: 1px solid rgba(100, 100, 100, 0.2);
+    padding: 4px;
 }
 
 .case-metadata {
@@ -348,11 +357,9 @@ pre {
 }
 
 body.vscode-light .case {
-    background: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0.9),
-        rgba(220, 220, 220, 0.9)
-    );
+    background: linear-gradient(to right,
+            rgba(255, 255, 255, 0.9),
+            rgba(220, 220, 220, 0.9));
     box-shadow: none;
     border-left: 5px solid rgba(0, 0, 0, 0.3);
     margin-bottom: 4px;
@@ -522,6 +529,14 @@ body.vscode-light .notification {
     background: rgb(58, 57, 57);
     color: white !important;
     border: 1px solid rgb(92, 95, 97);
+}
+
+.token-ok {
+    color: rgb(64, 175, 64);
+}
+
+.token-bad {
+    color: rgb(206, 40, 95);
 }
 
 /* @keyframes runs {

--- a/src/webview/frontend/app.css
+++ b/src/webview/frontend/app.css
@@ -618,3 +618,81 @@ hr {
         display: block !important;
     }
 }
+
+/* Lined editor */
+.lined-container {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: stretch;
+}
+
+.lined-gutter {
+    background: rgba(0, 0, 0, 0.08);
+    border: 1px solid rgba(100, 100, 100, 0.12);
+    border-right: none;
+    overflow-y: hidden;
+    max-height: 250px !important;
+}
+
+.lined-number {
+    padding: 0px 6px;
+    text-align: right;
+    font-family: Consolas, 'Ubuntu Mono', monospace;
+    color: rgba(255, 255, 255, 0.45);
+    box-sizing: content-box;
+}
+
+.lined-content>.pre-block,
+.lined-content>textarea {
+    border-left: none;
+}
+
+/* Remove any inner padding inside lined textareas */
+.lined-content>textarea {
+    padding: 0 !important;
+}
+
+.lined-container .lined-gutter+.lined-content>.pre-block,
+.lined-container .lined-gutter+.lined-content>textarea {
+    border-left: none;
+}
+
+.lined-number.is-hovered {
+    background: rgba(200, 200, 200, 0.08);
+}
+
+body.vscode-light .lined-gutter {
+    background: rgba(0, 0, 0, 0.03);
+}
+
+body.vscode-light .lined-number {
+    color: rgba(0, 0, 0, 0.45);
+}
+
+body.vscode-light .lined-number.is-hovered {
+    background: rgba(0, 0, 0, 0.06);
+}
+
+/* Overlay for diff rendering inside lined textareas */
+.lined-content {
+    position: relative;
+}
+
+.lined-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.lined-overlay-inner {
+    white-space: pre-wrap;
+    background: transparent;
+    color: inherit;
+    border: 0;
+    padding: 0;
+    max-height: none;
+    /* overlay should not clip vertically; base textarea limits height */
+    overflow: visible;
+}


### PR DESCRIPTION
**Rework `Cph › General: Save Location`**
Now .cph folder created inside Save Location.
Save location will be created instead of raising error.
It supports ${group} syntax 🔥
Description for the option is changed:
> Directory where new problem source files and their .prob metadata will be saved. Supports the ${group} placeholder (e.g. '${group}/'), which is replaced with the problem's group. Leave empty to save in the workspace root for sources and alongside sources in .cph for metadata.

**Rework finding .prob for code file**
Now it will check every .cph folder from down to top until it will find such .prob that points to the code file via `srcPath` (name of .prob may be any, but same name as code file is prioritized). Using such approach allow us to remove messy hash from .prob files.

**Auto-open CPH Judge only if associated .prob file exists**
If no .prob file exists, most probably, that is not a problem code file, but just some file (may be scratch, or util).

**`Ctrl+Alt+B` will not create new .prob until second invocation**
So, firstly it will open CPH Judge tab, and on second keybind shot will create .prob file with empty testset.

**Prettify .prob files**
It will be with `indent=2` so human will able to read those .json files.

**Speed up extension loading**
Set `retainWebviewContext` to `true` by default so IDE will keep extension in memory to open it instantly.

**Line number column and coloring**
Now we have line number with synchronized highlight on hovering, also it shifts first line for input if T-testcases pattern (common in CodeForces) is detected. And coloring for good and bad tokens. Relates-to: #572 #577
<img width="335" height="357" alt="image" src="https://github.com/user-attachments/assets/d8aeb01d-c1ba-4f37-a184-5014559a53e6" />

**Suppress warning about Content Security Policy**
There was a warning in Extension Host:
```
2025-09-09 02:41:20.879 [warning] DivyanshuAgrawal.competitive-programming-helper created a webview without a content security policy: https://aka.ms/vscode-webview-missing-csp
```
It was fixed by adding <meta> Content Security Policy in App and generating nonce for scripts.
