### PR TITLE
docs: fix typos in doc files

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -4,7 +4,7 @@ This document contains a basic developer guide to get started with the extension
 development. In case of any confusions/ need for additional information, please
 create an issue in the [repo](https://github.com/agrawal-d/cph). You should also
 take a look at the [user guide](user-guide.md) to understand the
-user-facingterms.
+user-facing terms.
 
 ## Architecture
 
@@ -65,10 +65,10 @@ in `dist/`.
 We recommend installing `Prettier` and `ESLint` VS Code extensions. Before
 commiting, make sure you are passing the following tests:
 
--   ESLint lint: `npm run lint`.
--   Jest unit tests: `npm run test`.
--   Typescript compilation: `npm run test-compile`.
--   Pre-publish bundling: `npm run vscode:prepublish`.
+- ESLint lint: `npm run lint`.
+- Jest unit tests: `npm run test`.
+- Typescript compilation: `npm run test-compile`.
+- Pre-publish bundling: `npm run vscode:prepublish`.
 
 ## Bundling as `.vsix`
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -16,5 +16,5 @@ the competitive programming helper extension (cph).
 cph is an extension for VS Code made to streamline your competitive programming
 experience across several popular sites. It saves your time by auto-compiling,
 running and judging your solutions. Using the 3rd party browser extension
-'Competitive Companion', you can extend it's functionality by auto-downloaing
+'Competitive Companion', you can extend it's functionality by auto-downloading
 and parsing testcases from problem statements online.


### PR DESCRIPTION
- Fix typo in readme.md: "auto-downloaing" -> "auto-downloading"
- Fix typo in dev-guide.md: "user-facingterms" -> "user-facing terms"