### PR TITLE
feat: POC support relative problem path when inside a VSCode workspace

### DIFF
--- a/src/companion.ts
+++ b/src/companion.ts
@@ -29,6 +29,12 @@ const COMPANION_LOGGING = false;
 export const submitKattisProblem = (problem: Problem) => {
     globalThis.reporter.sendTelemetryEvent(telmetry.SUBMIT_TO_KATTIS);
     const srcPath = problem.srcPath;
+    if (!srcPath) {
+        vscode.window.showErrorMessage(
+            'No source path available for this problem (cannot submit to Kattis)',
+        );
+        return;
+    }
     const homedir = os.homedir();
     const directoryChar = process.platform == 'win32' ? '\\' : '/';
     const submitPath = `${homedir}${directoryChar}.kattis${directoryChar}submit.py`;
@@ -71,9 +77,13 @@ export const submitKattisProblem = (problem: Problem) => {
 /** Stores a response to be submitted to CF page soon. */
 export const storeSubmitProblem = (problem: Problem) => {
     const srcPath = problem.srcPath;
+    if (!srcPath) {
+        globalThis.logger.error('No srcPath available to store submission');
+        return;
+    }
     const problemName = getProblemName(problem.url);
     const sourceCode = readFileSync(srcPath).toString();
-    const languageId = getLanguageId(problem.srcPath);
+    const languageId = getLanguageId(srcPath);
     savedResponse = {
         empty: false,
         url: problem.url,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { Problem } from './types';
 import { getSaveLocationPref } from './preferences';
 import crypto from 'crypto';
+import * as vscode from 'vscode';
 
 /**
  *  Get the location (file path) to save the generated problem file in. If save
@@ -15,12 +16,80 @@ export const getProbSaveLocation = (srcPath: string): string => {
     const savePreference = getSaveLocationPref();
     const srcFileName = path.basename(srcPath);
     const srcFolder = path.dirname(srcPath);
-    const hash = crypto
-        .createHash('md5')
-        .update(srcPath)
-        .digest('hex')
-        .substr(0);
-    const baseProbName = `.${srcFileName}_${hash}.prob`;
+    // If this file belongs to a workspace folder, prefer a deterministic
+    // relative-path-based filename. Otherwise fall back to the old
+    // `.<filename>_<md5>.prob` hash-based name.
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(
+        vscode.Uri.file(srcPath),
+    );
+
+    let baseProbName: string;
+
+    if (workspaceFolder) {
+        // compute path relative to workspace root and use $$ as separator
+        let rel = path.relative(workspaceFolder.uri.fsPath, srcPath);
+        // Remove any drive colon on Windows (e.g. C:)
+        rel = rel.replace(/:/g, '');
+        const parts = rel.split(path.sep);
+        baseProbName = `.${parts.join('$$')}.prob`;
+
+        // perform migration of old hashed .prob files into .cph/old (if using
+        // the per-folder .cph location). We only attempt this when save
+        // preference is not set (that's when .cph sits next to sources).
+        const cphFolder = path.join(srcFolder, '.cph');
+        try {
+            if (getSaveLocationPref() === '' && fs.existsSync(cphFolder)) {
+                const oldFolder = path.join(cphFolder, 'old');
+                const files = fs.readdirSync(cphFolder);
+                const oldRegex = /^(\..+)_[0-9a-f]{32}\.prob$/i;
+                for (const f of files) {
+                    const oldFileMatch = f.match(oldRegex);
+                    if (!oldFileMatch) continue;
+
+                    if (!fs.existsSync(oldFolder)) {
+                        fs.mkdirSync(oldFolder);
+                    }
+                    const from = path.join(cphFolder, f);
+                    const to = path.join(oldFolder, f);
+                    try {
+                        // Read the old problem file and write it to the new format
+                        const oldProblem = JSON.parse(
+                            fs.readFileSync(from).toString(),
+                        );
+                        const newProbPath = path.join(
+                            cphFolder,
+                            `${oldFileMatch[1]}.prob`,
+                        );
+                        // Don't include srcPath in the new format
+                        const toWrite = { ...oldProblem };
+                        delete toWrite.srcPath;
+                        fs.writeFileSync(
+                            newProbPath,
+                            JSON.stringify(toWrite, null, 2),
+                        );
+
+                        // Move the old file to old/
+                        fs.renameSync(from, to);
+                    } catch (e) {
+                        // If migration fails, skip and continue.
+                        globalThis.logger.error(
+                            `Failed to migrate ${from} -> ${to}: ${e}`,
+                        );
+                    }
+                }
+            }
+        } catch (e) {
+            globalThis.logger.error('Error during .prob migration', e);
+        }
+    } else {
+        const hash = crypto
+            .createHash('md5')
+            .update(srcPath)
+            .digest('hex')
+            .substr(0);
+        baseProbName = `.${srcFileName}_${hash}.prob`;
+    }
+
     const cphFolder = path.join(srcFolder, '.cph');
     if (savePreference && savePreference !== '') {
         return path.join(savePreference, baseProbName);
@@ -34,7 +103,10 @@ export const getProblem = (srcPath: string): Problem | null => {
     let problem: string;
     try {
         problem = fs.readFileSync(probPath).toString();
-        return JSON.parse(problem);
+        const parsed: Problem = JSON.parse(problem);
+        // populate srcPath in-memory so callers don't have to change.
+        parsed.srcPath ??= srcPath;
+        return parsed;
     } catch (err) {
         return null;
     }
@@ -52,7 +124,19 @@ export const saveProblem = (srcPath: string, problem: Problem) => {
 
     const probPath = getProbSaveLocation(srcPath);
     try {
-        fs.writeFileSync(probPath, JSON.stringify(problem));
+        // If this file belongs to a workspace folder, we omit srcPath from the
+        // on-disk JSON because it's encoded in the filename. We still keep it
+        // in-memory when returning/working with problems.
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(
+            vscode.Uri.file(srcPath),
+        );
+
+        let toWrite = problem;
+        if (workspaceFolder) {
+            toWrite = { ...problem };
+            delete toWrite.srcPath;
+        }
+        fs.writeFileSync(probPath, JSON.stringify(toWrite, null, 2));
     } catch (err) {
         throw new Error(err as string);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,9 @@ export type Problem = {
     timeLimit: number;
     group: string;
     tests: TestCase[];
-    srcPath: string;
+    // srcPath is optional on-disk for workspace mode (the path is encoded in the
+    // .prob filename). In-memory we populate it when needed.
+    srcPath?: string;
     local?: boolean;
 };
 

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -57,7 +57,21 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                     }
 
                     case 'save': {
-                        saveProblem(message.problem.srcPath, message.problem);
+                        // message.problem may not contain srcPath on-disk for
+                        // workspace mode. Prefer the provided srcPath, fall
+                        // back to the active editor's document path.
+                        const activeEditor = vscode.window.activeTextEditor;
+                        let srcPath = message.problem.srcPath;
+                        if (!srcPath && activeEditor) {
+                            srcPath = activeEditor.document.fileName;
+                        }
+                        if (!srcPath) {
+                            globalThis.logger.error(
+                                'No srcPath available to save problem',
+                            );
+                            break;
+                        }
+                        saveProblem(srcPath, message.problem);
                         break;
                     }
 
@@ -76,7 +90,20 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                             command: 'new-problem',
                             problem: undefined,
                         });
-                        await deleteProblemFile(message.problem.srcPath);
+                        {
+                            const activeEditor = vscode.window.activeTextEditor;
+                            let srcPath = message.problem.srcPath;
+                            if (!srcPath && activeEditor) {
+                                srcPath = activeEditor.document.fileName;
+                            }
+                            if (!srcPath) {
+                                globalThis.logger.error(
+                                    'No srcPath available to delete problem',
+                                );
+                                break;
+                            }
+                            await deleteProblemFile(srcPath);
+                        }
                         break;
                     }
 

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
-import { getProbSaveLocation } from '../parser';
-import { existsSync, readFileSync } from 'fs';
-import { Problem } from '../types';
+import { getProblem } from '../parser';
 import { getJudgeViewProvider } from '../extension';
 import { getProblemForDocument } from '../utils';
 import { getAutoShowJudgePref } from '../preferences';
@@ -60,13 +58,11 @@ export const editorChanged = async (e: vscode.TextEditor | undefined) => {
 export const editorClosed = (e: vscode.TextDocument) => {
     globalThis.logger.log('Closed editor:', e.uri.fsPath);
     const srcPath = e.uri.fsPath;
-    const probPath = getProbSaveLocation(srcPath);
+    const problem = getProblem(srcPath);
 
-    if (!existsSync(probPath)) {
+    if (!problem) {
         return;
     }
-
-    const problem: Problem = JSON.parse(readFileSync(probPath).toString());
 
     if (getJudgeViewProvider().problemPath === problem.srcPath) {
         getJudgeViewProvider().extensionToJudgeViewMessage({

--- a/src/webview/processRunSingle.ts
+++ b/src/webview/processRunSingle.ts
@@ -19,7 +19,18 @@ export const runSingleAndSave = async (
         globalThis.reporter.sendTelemetryEvent(telmetry.RUN_TESTCASE);
     }
     globalThis.logger.log('Run and save started', problem, id);
-    const srcPath = problem.srcPath;
+    let srcPath = problem.srcPath;
+    if (!srcPath) {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+            srcPath = editor.document.fileName;
+        } else {
+            globalThis.logger.error(
+                `No srcPath available to run single testcase`,
+            );
+            return;
+        }
+    }
     const language = getLanguage(srcPath);
     const binPath = getBinSaveLocation(srcPath);
     const idx = problem.tests.findIndex((value) => value.id === id);


### PR DESCRIPTION
Why: I use git to store my code files across machines with different OSes, and since the problem paths are absolute, they don't work between machines.

Main points:
- Use workspace root as the relative root
- Remove `srcPath` entirely, encode the entire path in the file name. Path `./a/b/c/file.cpp` becomes file name `a$$b$$c$$file.cpp`. Pros:
  - O(1) lookup
  - Doesn't need to deserialize JSON to find the file name
  - Easy to update the path when the code file is moved/renamed.