### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+    "files.exclude": {
+        "**/*.bin": true,
+        "**/*.out": true,
+        "**/a.out": true
+    },
     "eslint.enable": true,
     "files.associations": {
         "iostream": "cpp"


### PR DESCRIPTION
While using the CPH extension in VS Code, I noticed that the .bin files were still visible in the Explorer panel even after updating the settings.json file to hide them. This pull request fixes the issue to ensure that .bin files are properly hidden.