### PR TITLE
Add multi-language template support

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,6 +368,56 @@
                     "default": "",
                     "description": "The path to the template file that will be used when creating a new file for the default language via Competitive Companion. For Java templates, use 'CLASS_NAME' as a placeholder for the class name like 'class CLASS_NAME{...}'"
                 },
+                "cph.language.c.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for C files. If a directory is provided, files named 'c', 'c.tpl' or 'c.template' will be considered."
+                },
+                "cph.language.cpp.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for C++ files. If a directory is provided, files named 'cpp', 'cpp.tpl' or 'cpp.template' will be considered."
+                },
+                "cph.language.python.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Python files. If a directory is provided, files named 'python', 'py.tpl' or 'py.template' will be considered."
+                },
+                "cph.language.rust.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Rust files."
+                },
+                "cph.language.js.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for JavaScript files."
+                },
+                "cph.language.java.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Java files. Use 'CLASS_NAME' placeholder in templates for class name substitution."
+                },
+                "cph.language.ruby.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Ruby files."
+                },
+                "cph.language.csharp.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for C# files."
+                },
+                "cph.language.go.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Go files."
+                },
+                "cph.language.haskell.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Haskell files."
+                },
                 "cph.general.autoShowJudge": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
This update adds support for per-language code templates in Competitive Programming Helper (CPH).

Previously, CPH only allowed one global default template for all languages.
Now, users can configure a separate template for each language via VS Code settings:
`{
  "cph.language.cpp.templateFileLocation": "/path/to/cpp_template.cpp",
  "cph.language.python.templateFileLocation": "/path/to/py_template.py",
  "cph.language.java.templateFileLocation": "/path/to/java/template/dir",
  "cph.general.defaultLanguageTemplateFileLocation": "/path/to/default.tpl"
}`
When importing a problem via Competitive Companion,
CPH will automatically detect the selected language and apply the corresponding template.
If no per-language template is defined, it falls back to the global default template.

This feature improves workflow flexibility for users working with multiple languages.