### PR TITLE
Add multi-language template support

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,6 +368,56 @@
                     "default": "",
                     "description": "The path to the template file that will be used when creating a new file for the default language via Competitive Companion. For Java templates, use 'CLASS_NAME' as a placeholder for the class name like 'class CLASS_NAME{...}'"
                 },
+                "cph.language.c.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for C files. If a directory is provided, files named 'c', 'c.tpl' or 'c.template' will be considered."
+                },
+                "cph.language.cpp.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for C++ files. If a directory is provided, files named 'cpp', 'cpp.tpl' or 'cpp.template' will be considered."
+                },
+                "cph.language.python.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Python files. If a directory is provided, files named 'python', 'py.tpl' or 'py.template' will be considered."
+                },
+                "cph.language.rust.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Rust files."
+                },
+                "cph.language.js.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for JavaScript files."
+                },
+                "cph.language.java.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Java files. Use 'CLASS_NAME' placeholder in templates for class name substitution."
+                },
+                "cph.language.ruby.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Ruby files."
+                },
+                "cph.language.csharp.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for C# files."
+                },
+                "cph.language.go.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Go files."
+                },
+                "cph.language.haskell.templateFileLocation": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Template file or directory for Haskell files."
+                },
                 "cph.general.autoShowJudge": {
                     "type": "boolean",
                     "default": true,

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -200,7 +200,9 @@ const handleNewProblem = async (problem: Problem) => {
         const choices = userChoices.filter((x) => allChoices.has(x));
         const selected = await vscode.window.showQuickPick(choices);
         if (!selected) {
-            vscode.window.showInformationMessage('Aborted creation of new file');
+            vscode.window.showInformationMessage(
+                'Aborted creation of new file',
+            );
             return;
         }
         chosenLang = selected;
@@ -244,7 +246,8 @@ const handleNewProblem = async (problem: Problem) => {
         // 1) per-language template file/location (cph.language.<lang>.templateFileLocation)
         // 2) global default template location (cph.general.defaultLanguageTemplateFileLocation)
         const perLangTemplate = getLanguageTemplateFileLocation(chosenLang);
-        const templateLocation = perLangTemplate ?? getDefaultLanguageTemplateFileLocation();
+        const templateLocation =
+            perLangTemplate ?? getDefaultLanguageTemplateFileLocation();
         if (templateLocation !== null) {
             if (!existsSync(templateLocation)) {
                 vscode.window.showErrorMessage(
@@ -282,7 +285,10 @@ const handleNewProblem = async (problem: Problem) => {
                         candidateFile = templateLocation;
                     }
                 } catch (err) {
-                    globalThis.logger.error('Error while checking template path', err);
+                    globalThis.logger.error(
+                        'Error while checking template path',
+                        err,
+                    );
                 }
 
                 if (candidateFile === null) {
@@ -291,15 +297,27 @@ const handleNewProblem = async (problem: Problem) => {
                     );
                 } else {
                     try {
-                        let templateContents = readFileSync(candidateFile).toString();
+                        let templateContents =
+                            readFileSync(candidateFile).toString();
                         if (extn == 'java') {
-                            const className = path.basename(problemFileName, '.java');
-                            templateContents = templateContents.replace('CLASS_NAME', className);
+                            const className = path.basename(
+                                problemFileName,
+                                '.java',
+                            );
+                            templateContents = templateContents.replace(
+                                'CLASS_NAME',
+                                className,
+                            );
                         }
                         writeFileSync(srcPath, templateContents);
                     } catch (err) {
-                        globalThis.logger.error('Failed to read/write template file', err);
-                        vscode.window.showErrorMessage(`Failed to apply template: ${err}`);
+                        globalThis.logger.error(
+                            'Failed to read/write template file',
+                            err,
+                        );
+                        vscode.window.showErrorMessage(
+                            `Failed to apply template: ${err}`,
+                        );
                     }
                 }
             }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -119,6 +119,20 @@ export const getDefaultLanguageTemplateFileLocation = (): string | null => {
     return pref;
 };
 
+/**
+ * Per-language template file/location preference.
+ * Preference key pattern: `language.<lang>.templateFileLocation`.
+ */
+export const getLanguageTemplateFileLocation = (
+    lang: string,
+): string | null => {
+    if (!lang) return null;
+    const key = `language.${lang}.templateFileLocation`;
+    const pref = workspace.getConfiguration('cph').get(key);
+    if (!pref || pref === '') return null;
+    return pref as string;
+};
+
 export const getCCommand = (): string =>
     getPreference('language.c.Command') || 'gcc';
 export const getCppCommand = (): string =>


### PR DESCRIPTION
This update introduces multi-language template support for Competitive Programming Helper (CPH).  

Changes include:
- Added a function to get language-specific template file locations.
- Companion extension now applies templates based on the user's selected programming language.
- Falls back to the global default template if a language-specific template is not found.
- Supports popular languages including C, C++, Java, Python, JavaScript, Go, Rust, Ruby, Haskell, and C#.
- Ensures proper application of templates for Java classes (replaces CLASS_NAME dynamically).
- Handles missing or invalid template paths gracefully with informative error messages.

This enhancement improves the workflow for users who solve problems in multiple languages, allowing templates to be applied automatically per language.