### PR TITLE
Add an option to set ONLINE_JUDGE by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,11 @@
                     "default": false,
                     "description": "If enabled, non-empty standard error will not result in testcase failing."
                 },
+                "cph.general.defaultOnlineJudge": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable Set ONLINE_JUDGE as default."
+                },
                 "cph.language.c.Args": {
                     "title": "Compilation flags for .c files",
                     "type": "string",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8,15 +8,17 @@ import {
     getCppOutputArgPref,
     getSaveLocationPref,
     getHideStderrorWhenCompiledOK,
+    getDefaultOnlineJudge,
 } from './preferences';
 import * as vscode from 'vscode';
 import { getJudgeViewProvider } from './extension';
 import { toAsciiFilename } from './utilsPure';
-export let onlineJudgeEnv = false;
+export let onlineJudgeEnv = getDefaultOnlineJudge();
 
 export const setOnlineJudgeEnv = (value: boolean) => {
     onlineJudgeEnv = value;
     globalThis.logger.log('online judge env:', onlineJudgeEnv);
+    globalThis.logger.log('default online judge env', getDefaultOnlineJudge());
 };
 
 /**
@@ -231,7 +233,7 @@ const createDotnetProject = async (
             if (exitCode !== 0) {
                 ocWrite(
                     `Exit code: ${exitCode} Errors while creating new .NET project:\n` +
-                        error,
+                    error,
                 );
                 ocShow();
                 resolve(false);
@@ -241,7 +243,7 @@ const createDotnetProject = async (
             if (!hideWarningsWhenCompiledOK && error.trim() !== '') {
                 ocWrite(
                     `Exit code: ${exitCode} Warnings while creating new .NET project:\n ` +
-                        error,
+                    error,
                 );
                 ocShow();
             }
@@ -356,8 +358,8 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
             globalThis.logger.error(err);
             ocWrite(
                 'Errors while compiling:\n' +
-                    err.message +
-                    `\n\nHint: Is the compiler ${language.compiler} installed? Check the compiler command in cph settings for the current language.`,
+                err.message +
+                `\n\nHint: Is the compiler ${language.compiler} installed? Check the compiler command in cph settings for the current language.`,
             );
             getJudgeViewProvider().extensionToJudgeViewMessage({
                 command: 'compiling-stop',
@@ -392,7 +394,7 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
             if (!hideWarningsWhenCompiledOK && error.trim() !== '') {
                 ocWrite(
                     `Exit code: ${exitCode} Warnings while compiling:\n ` +
-                        error,
+                    error,
                 );
                 ocShow();
             }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -233,7 +233,7 @@ const createDotnetProject = async (
             if (exitCode !== 0) {
                 ocWrite(
                     `Exit code: ${exitCode} Errors while creating new .NET project:\n` +
-                    error,
+                        error,
                 );
                 ocShow();
                 resolve(false);
@@ -243,7 +243,7 @@ const createDotnetProject = async (
             if (!hideWarningsWhenCompiledOK && error.trim() !== '') {
                 ocWrite(
                     `Exit code: ${exitCode} Warnings while creating new .NET project:\n ` +
-                    error,
+                        error,
                 );
                 ocShow();
             }
@@ -358,8 +358,8 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
             globalThis.logger.error(err);
             ocWrite(
                 'Errors while compiling:\n' +
-                err.message +
-                `\n\nHint: Is the compiler ${language.compiler} installed? Check the compiler command in cph settings for the current language.`,
+                    err.message +
+                    `\n\nHint: Is the compiler ${language.compiler} installed? Check the compiler command in cph settings for the current language.`,
             );
             getJudgeViewProvider().extensionToJudgeViewMessage({
                 command: 'compiling-stop',
@@ -394,7 +394,7 @@ export const compileFile = async (srcPath: string): Promise<boolean> => {
             if (!hideWarningsWhenCompiledOK && error.trim() !== '') {
                 ocWrite(
                     `Exit code: ${exitCode} Warnings while compiling:\n ` +
-                    error,
+                        error,
                 );
                 ocShow();
             }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -43,6 +43,9 @@ export const getSaveLocationPref = (): string => {
 export const getHideStderrorWhenCompiledOK = (): boolean =>
     getPreference('general.hideStderrorWhenCompiledOK');
 
+export const getDefaultOnlineJudge = (): boolean =>
+    getPreference('general.defaultOnlineJudge');
+
 export const getIgnoreSTDERRORPref = (): string =>
     getPreference('general.ignoreSTDERROR');
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 export type prefSection =
     | 'general.saveLocation'
     | 'general.defaultLanguage'
+    | 'general.defaultOnlineJudge'
     | 'general.timeOut'
     | 'general.hideStderrorWhenCompiledOK'
     | 'general.ignoreSTDERROR'
@@ -126,7 +127,7 @@ export type RunAllCommand = {
 
 export type OnlineJudgeEnv = {
     command: 'online-judge-env';
-    value: boolean;
+    value: string;
 };
 
 export type KillRunningCommand = {

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -12,6 +12,7 @@ import {
     getRemoteServerAddressPref,
     getLiveUserCountPref,
     getRetainWebviewContextPref,
+    getDefaultOnlineJudge,
 } from '../preferences';
 import { setOnlineJudgeEnv } from '../compiler';
 
@@ -26,7 +27,7 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
         return this._view === undefined;
     }
 
-    constructor(private readonly _extensionUri: vscode.Uri) {}
+    constructor(private readonly _extensionUri: vscode.Uri) { }
 
     public resolveWebviewView(webviewView: vscode.WebviewView) {
         this._view = webviewView;
@@ -90,7 +91,20 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                     }
 
                     case 'online-judge-env': {
-                        setOnlineJudgeEnv(message.value);
+                        switch (message.value) {
+                            case 'true': {
+                                setOnlineJudgeEnv(true);
+                                break;
+                            }
+                            case 'false': {
+                                setOnlineJudgeEnv(false);
+                                break;
+                            }
+                            case 'default': {
+                                setOnlineJudgeEnv(getDefaultOnlineJudge());
+                                break;
+                            }
+                        }
                         break;
                     }
 
@@ -274,7 +288,7 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                                 });
                                 vscodeApi.postMessage({
                                     command: 'online-judge-env',
-                                    value:false,
+                                    value: 'default',
                                 });
                                 globalThis.logger.log("Requested initial problem");
                             },

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -27,7 +27,7 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
         return this._view === undefined;
     }
 
-    constructor(private readonly _extensionUri: vscode.Uri) { }
+    constructor(private readonly _extensionUri: vscode.Uri) {}
 
     public resolveWebviewView(webviewView: vscode.WebviewView) {
         this._view = webviewView;

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -4,7 +4,10 @@ import { existsSync, readFileSync } from 'fs';
 import { Problem } from '../types';
 import { getJudgeViewProvider } from '../extension';
 import { getProblemForDocument } from '../utils';
-import { getAutoShowJudgePref } from '../preferences';
+import {
+    getAutoShowJudgePref,
+    getDefaultOnlineJudge,
+} from '../preferences';
 import { setOnlineJudgeEnv } from '../compiler';
 
 /**
@@ -23,7 +26,7 @@ export const editorChanged = async (e: vscode.TextEditor | undefined) => {
             command: 'new-problem',
             problem: undefined,
         });
-        setOnlineJudgeEnv(false); // reset the non-debug mode set in webview.
+        setOnlineJudgeEnv(getDefaultOnlineJudge()); // reset the non-debug mode set in webview as configured.
         return;
     }
 
@@ -31,7 +34,7 @@ export const editorChanged = async (e: vscode.TextEditor | undefined) => {
         return;
     }
 
-    setOnlineJudgeEnv(false); // reset the non-debug mode set in webview.
+    setOnlineJudgeEnv(getDefaultOnlineJudge()); // reset the non-debug mode set in webview as configured.
 
     const problem = getProblemForDocument(e.document);
 

--- a/src/webview/editorChange.ts
+++ b/src/webview/editorChange.ts
@@ -4,10 +4,7 @@ import { existsSync, readFileSync } from 'fs';
 import { Problem } from '../types';
 import { getJudgeViewProvider } from '../extension';
 import { getProblemForDocument } from '../utils';
-import {
-    getAutoShowJudgePref,
-    getDefaultOnlineJudge,
-} from '../preferences';
+import { getAutoShowJudgePref, getDefaultOnlineJudge } from '../preferences';
 import { setOnlineJudgeEnv } from '../compiler';
 
 /**

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -628,12 +628,13 @@ function Judge(props: {
                     )}
                 </span>
                 <span
-                    className={`pass-rate ${numPassed === total
-                        ? 'pass-all'
-                        : numPassed === 0
-                            ? 'fail-all'
-                            : ''
-                        }`}
+                    className={`pass-rate ${
+                        numPassed === total
+                            ? 'pass-all'
+                            : numPassed === 0
+                              ? 'fail-all'
+                              : ''
+                    }`}
                 >
                     {numPassed} / {total} passed{' '}
                 </span>
@@ -656,8 +657,9 @@ function Judge(props: {
                 <div>
                     <span
                         onClick={toggleOnlineJudgeEnv}
-                        className={`oj-box ${onlineJudgeEnv ? 'oj-enabled' : ''
-                            }`}
+                        className={`oj-box ${
+                            onlineJudgeEnv ? 'oj-enabled' : ''
+                        }`}
                     >
                         {onlineJudgeEnv ? '☑' : '☐'}{' '}
                         <span className="oj-code">Set ONLINE_JUDGE</span>

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -208,9 +208,11 @@ function Judge(props: {
     };
 
     const refreshOnlineJudge = () => {
+        let sendEnv = 'false';
+        if (onlineJudgeEnv) sendEnv = 'true';
         sendMessageToVSCode({
             command: 'online-judge-env',
-            value: onlineJudgeEnv,
+            value: sendEnv,
         });
     };
 
@@ -324,9 +326,11 @@ function Judge(props: {
     const toggleOnlineJudgeEnv = () => {
         const newEnv = !onlineJudgeEnv;
         setOnlineJudgeEnv(newEnv);
+        let sendEnv = 'false';
+        if (newEnv) sendEnv = 'true';
         sendMessageToVSCode({
             command: 'online-judge-env',
-            value: newEnv,
+            value: sendEnv,
         });
     };
 
@@ -624,13 +628,12 @@ function Judge(props: {
                     )}
                 </span>
                 <span
-                    className={`pass-rate ${
-                        numPassed === total
-                            ? 'pass-all'
-                            : numPassed === 0
-                              ? 'fail-all'
-                              : ''
-                    }`}
+                    className={`pass-rate ${numPassed === total
+                        ? 'pass-all'
+                        : numPassed === 0
+                            ? 'fail-all'
+                            : ''
+                        }`}
                 >
                     {numPassed} / {total} passed{' '}
                 </span>
@@ -653,9 +656,8 @@ function Judge(props: {
                 <div>
                     <span
                         onClick={toggleOnlineJudgeEnv}
-                        className={`oj-box ${
-                            onlineJudgeEnv ? 'oj-enabled' : ''
-                        }`}
+                        className={`oj-box ${onlineJudgeEnv ? 'oj-enabled' : ''
+                            }`}
                     >
                         {onlineJudgeEnv ? '☑' : '☐'}{' '}
                         <span className="oj-code">Set ONLINE_JUDGE</span>


### PR DESCRIPTION
Added an option cph.genenral.defaultOnlineJudge.
ONLINE_JUDGE flag will be set  by default when the  option is on.
Change OnlineJudgeEnv.value from boolean to string,which allow 'false','true' and 'default'.