### PR TITLE
feat: Add Cangjie language support with compilation settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,6 +313,17 @@
                     "default": "node",
                     "description": "Command used to compile .js files."
                 },
+                "cph.language.cangjie.Args": {
+                    "title": "Compilation flags for Cangjie",
+                    "type": "string",
+                    "default": "",
+                    "description": "Space seperated additional flags passed to cangjie-compiler while compiling your file."
+                },
+                "cph.language.cangjie.Command": {
+                    "type": "string",
+                    "default": "cjc",
+                    "description": "Command used to compile .cj files."
+                },
                 "cph.general.firstTime": {
                     "title": "Show welcome message",
                     "type": "boolean",
@@ -334,7 +345,8 @@
                         "ruby",
                         "csharp",
                         "go",
-                        "haskell"
+                        "haskell",
+                        "cangjie"
                     ],
                     "description": "The default language for problems imported via Competitive Companion (None will give option to select language on importing problem every time)"
                 },

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -169,6 +169,10 @@ const getFlags = (language: Language, srcPath: string): string[] => {
             }
             break;
         }
+        case 'cangjie': {
+            ret = [srcPath, '-o', getBinSaveLocation(srcPath), ...args];
+            break;
+        }
         default: {
             ret = [];
             break;

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export default {
         js: 'js',
         go: 'go',
         hs: 'hs',
+        cangjie: 'cj',
     },
     compilers: {
         c: 'gcc',
@@ -35,6 +36,7 @@ export default {
         js: 'node',
         go: 'go',
         hs: 'hs',
+        cj: 'cjc',
     },
     compilerToId: {
         'GNU G++17 7.3.0': 54,
@@ -88,6 +90,7 @@ export default {
         'hs',
         'rb',
         'cs',
+        'cj',
     ],
     skipCompile: ['py', 'js', 'rb'],
 };

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -88,6 +88,9 @@ export const getGoArgsPref = (): string[] =>
 export const getCSharpArgsPref = (): string[] =>
     getPreference('language.csharp.Args').split(' ') || [];
 
+export const getCangejieArgsPref = (): string[] =>
+    getPreference('language.cangjie.Args').split(' ') || [];
+
 export const getRemoteServerAddressPref = (): string =>
     getPreference('general.remoteServerAddress') || '';
 
@@ -139,6 +142,8 @@ export const getHaskellCommand = (): string =>
     getPreference('language.haskell.Command') || 'ghc';
 export const getCSharpCommand = (): string =>
     getPreference('language.csharp.Command') || 'dotnet';
+export const getCangjieCommand = (): string =>
+    getPreference('language.cangjie.Command') || 'cangjie-compiler';
 
 export const getMenuChoices = (): string[] =>
     getPreference('general.menuChoices').split(' ');
@@ -199,6 +204,11 @@ export const getLanguageId = (srcPath: string): number => {
             compiler = getPreference('language.csharp.SubmissionCompiler');
             break;
         }
+
+        // case '.cj': {
+        //     compiler = getPreference('language.cangjie.SubmissionCompiler');
+        //     break;
+        // }
     }
     if (compiler == null) return -1;
     for (const [_compiler, id] of Object.entries(config.compilerToId)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,9 @@ export type prefSection =
     | 'language.haskell.Args'
     | 'language.haskell.SubmissionCompiler'
     | 'language.haskell.Command'
+    | 'language.cangjie.Args'
+    // | 'language.cangjie.SubmissionCompiler'  // Not support now
+    | 'language.cangjie.Command'
     | 'general.retainWebviewContext'
     | 'general.autoShowJudge'
     | 'general.defaultLanguageTemplateFileLocation'
@@ -71,7 +74,8 @@ export type LangNames =
     | 'js'
     | 'go'
     | 'hs'
-    | 'csharp';
+    | 'csharp'
+    | 'cangjie';
 
 export type TestCase = {
     input: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,7 @@ import {
     getGoArgsPref,
     getHaskellArgsPref,
     getCSharpArgsPref,
+    getCangejieArgsPref,
     getCCommand,
     getCppCommand,
     getPythonCommand,
@@ -27,6 +28,7 @@ import {
     getGoCommand,
     getHaskellCommand,
     getCSharpCommand,
+    getCangjieCommand,
 } from './preferences';
 import { Language, Problem } from './types';
 import telmetry from './telmetry';
@@ -129,6 +131,14 @@ export const getLanguage = (srcPath: string): Language => {
                 name: langName,
                 args: [...getCSharpArgsPref()],
                 compiler: getCSharpCommand(),
+                skipCompile: false,
+            };
+        }
+        case 'cangjie': {
+            return {
+                name: langName,
+                args: [...getCangejieArgsPref()],
+                compiler: getCangjieCommand(),
                 skipCompile: false,
             };
         }


### PR DESCRIPTION
This pull request adds support for the Cangjie programming language to the project, including configuration options, compiler integration, and preference management. The changes ensure that Cangjie is treated as a first-class language alongside existing supported languages.

### Cangjie language support integration:

* Added Cangjie (`cangjie`/`cj`) as a supported language in language lists, language mappings, and default language options in `package.json` and `src/config.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L337-R349) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R26) [[3]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R39) [[4]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R93)
* Introduced new configuration options for Cangjie compilation flags and compiler command in `package.json` and `src/types.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R316-R326) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR49-R51)
* Implemented retrieval and usage of Cangjie-specific preferences and commands in `src/preferences.ts` and imported them where necessary. [[1]](diffhunk://#diff-9f28e7b8e8054a3640ef95c83135aef4824c13a15ca231f9c02707ae4948db93R91-R93) [[2]](diffhunk://#diff-9f28e7b8e8054a3640ef95c83135aef4824c13a15ca231f9c02707ae4948db93R145-R146) [[3]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R20) [[4]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R31)
* Updated the compiler argument generation logic to handle Cangjie source files in `src/compiler.ts`.
* Extended language detection and handling to recognize and process Cangjie files in `src/utils.ts`, including argument and command retrieval. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R137-R144) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL74-R78)

### Additional notes:

There is a commented-out section in `src/preferences.ts` for a potential Cangjie submission compiler, indicating future extensibility.

### About Cangjie:
**Cangjie** is a modern, statically typed, and multi-paradigm programming language created by Huawei. Built for the era of all-scenario intelligence, it serves as a core language for native **HarmonyOS** application development.

You can find the official documentation and resources here:
*   **Website:** [https://cangjie-lang.cn/en](https://cangjie-lang.cn/en)
*   **Documentation:** [https://cangjie-lang.cn/en/docs](https://cangjie-lang.cn/en/docs)