### PR TITLE
feat: use PascalCase for Java file and class names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,8 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+		
+
 		{
 			"name": "Run Extension",
 			"type": "extensionHost",

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -18,7 +18,7 @@ import {
 import { getProblemName } from './submit';
 import { spawn } from 'child_process';
 import { getJudgeViewProvider } from './extension';
-import { words_in_text } from './utilsPure';
+import { words_in_text, toPascalCase } from './utilsPure';
 import telmetry from './telmetry';
 import os from 'os';
 
@@ -166,11 +166,19 @@ export const getProblemFileName = (problem: Problem, ext: string) => {
         );
 
         const words = words_in_text(problem.name);
+        let baseName: string;
         if (words === null) {
-            return `${problem.name.replace(/\W+/g, '_')}.${ext}`;
+            baseName = problem.name.replace(/\W+/g, '_');
         } else {
-            return `${words.join('_')}.${ext}`;
+            baseName = words.join('_');
         }
+
+        // For Java, use PascalCase without underscores
+        if (ext === 'java') {
+            baseName = toPascalCase(baseName);
+        }
+
+        return `${baseName}.${ext}`;
     }
 };
 

--- a/src/tests/utilsPure.test.ts
+++ b/src/tests/utilsPure.test.ts
@@ -1,5 +1,5 @@
 globalThis.logger = { ...console };
-import { words_in_text } from '../utilsPure';
+import { words_in_text, toPascalCase } from '../utilsPure';
 
 describe('problem name parser', () => {
     test('mix of latin, non latin and numbers', () => {
@@ -18,5 +18,53 @@ describe('problem name parser', () => {
         const output = ['grapes'];
         const input = 'grapes';
         expect(words_in_text(input)).toEqual(output);
+    });
+});
+
+describe('toPascalCase', () => {
+    test('converts underscore-separated words to PascalCase', () => {
+        expect(toPascalCase('two_sum')).toBe('TwoSum');
+    });
+
+    test('handles multiple words', () => {
+        expect(toPascalCase('hello_world_test')).toBe('HelloWorldTest');
+    });
+
+    test('handles single word', () => {
+        expect(toPascalCase('hello')).toBe('Hello');
+    });
+
+    test('handles mixed case input', () => {
+        expect(toPascalCase('HELLO_WORLD')).toBe('HelloWorld');
+    });
+
+    test('preserves numbers as-is', () => {
+        expect(toPascalCase('problem_123_test')).toBe('Problem123Test');
+    });
+
+    test('prefixes with Problem when result starts with number', () => {
+        expect(toPascalCase('123_456')).toBe('Problem123456');
+    });
+
+    test('prefixes single number with Problem', () => {
+        expect(toPascalCase('123')).toBe('Problem123');
+    });
+
+    test('prefixes when starts with number followed by words', () => {
+        expect(toPascalCase('123_hello_world')).toBe('Problem123HelloWorld');
+    });
+
+    test('handles empty string', () => {
+        expect(toPascalCase('')).toBe('');
+    });
+
+    test('handles consecutive underscores', () => {
+        expect(toPascalCase('hello__world')).toBe('HelloWorld');
+    });
+
+    test('handles real problem names', () => {
+        expect(toPascalCase('A_Watermelon')).toBe('AWatermelon');
+        expect(toPascalCase('Two_Sum')).toBe('TwoSum');
+        expect(toPascalCase('Binary_Search_Tree')).toBe('BinarySearchTree');
     });
 });

--- a/src/utilsPure.ts
+++ b/src/utilsPure.ts
@@ -7,6 +7,32 @@ export const words_in_text = function (text: string) {
 };
 
 /**
+ * Converts a string with underscores to PascalCase.
+ * Example: "two_sum" -> "TwoSum", "hello_world_123" -> "HelloWorld123"
+ * If the result starts with a digit, prefixes with "Problem" (Java class names can't start with numbers).
+ * @param input The input string with underscores.
+ * @returns PascalCase string without underscores, valid as a Java class name.
+ */
+export const toPascalCase = (input: string): string => {
+    const result = input
+        .split('_')
+        .map((word) => {
+            if (word.length === 0) return '';
+            // Check if the word is all digits - keep as is
+            if (/^\d+$/.test(word)) return word;
+            return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        })
+        .join('');
+
+    // Java class names cannot start with a number
+    if (/^\d/.test(result)) {
+        return 'Problem' + result;
+    }
+
+    return result;
+};
+
+/**
  * Converts a string to an ASCII-safe filename.
  * Non-ASCII characters are replaced with their Unicode code point in hexadecimal format.
  * @param input The input string to convert.


### PR DESCRIPTION
Java files now use PascalCase instead of underscore_separated names.