### PR TITLE
feat: add output diff utility with inline diff view

### DIFF
--- a/src/tests/diffOutput.test.ts
+++ b/src/tests/diffOutput.test.ts
@@ -1,0 +1,109 @@
+import { diffOutput } from '../utils/diffOutput';
+
+describe('diffOutput — line-level', () => {
+    it('exact match returns isMatch true', () => {
+        expect(diffOutput('42\n', '42\n').isMatch).toBe(true);
+    });
+
+    it('single changed line is detected', () => {
+        const r = diffOutput('42\n', '43\n');
+        expect(r.isMatch).toBe(false);
+        expect(r.lines[0].type).toBe('changed');
+        expect(r.lines[0].expected).toBe('42');
+        expect(r.lines[0].received).toBe('43');
+    });
+
+    it('extra line in received is detected', () => {
+        const r = diffOutput('1\n2\n', '1\n2\n3\n');
+        expect(r.isMatch).toBe(false);
+        expect(r.lines[2].type).toBe('extra');
+        expect(r.lines[2].received).toBe('3');
+        expect(r.lines[2].expected).toBeNull();
+    });
+
+    it('missing line in received is detected', () => {
+        const r = diffOutput('1\n2\n3\n', '1\n2\n');
+        expect(r.isMatch).toBe(false);
+        expect(r.lines[2].type).toBe('missing');
+        expect(r.lines[2].received).toBeNull();
+    });
+
+    it('CRLF line endings are normalised', () => {
+        expect(diffOutput('42\r\n', '42\n').isMatch).toBe(true);
+    });
+
+    it('trailing whitespace per line is normalised', () => {
+        expect(diffOutput('42  \n', '42\n').isMatch).toBe(true);
+    });
+
+    it('multiline exact match', () => {
+        const r = diffOutput('1\n2\n3\n', '1\n2\n3\n');
+        expect(r.isMatch).toBe(true);
+        expect(r.lines).toHaveLength(3);
+        r.lines.forEach((l) => expect(l.type).toBe('match'));
+    });
+
+    it('summary text is correct for a single diff', () => {
+        expect(diffOutput('1\n', '2\n').summary).toBe('1 line differs.');
+    });
+
+    it('summary text is correct for multiple diffs', () => {
+        expect(diffOutput('1\n2\n', '3\n4\n').summary).toBe('2 lines differ.');
+    });
+
+    it('summary text is correct when all match', () => {
+        expect(diffOutput('42\n', '42\n').summary).toBe('All lines match.');
+    });
+
+    it('line numbers are 1-based', () => {
+        const r = diffOutput('a\nb\n', 'a\nb\n');
+        expect(r.lines[0].lineNumber).toBe(1);
+        expect(r.lines[1].lineNumber).toBe(2);
+    });
+});
+
+describe('diffOutput — token-level LCS diff', () => {
+    it('extra tokens in received are marked extra', () => {
+        const r = diffOutput('0 2 3 6 1 5', '0 2 3 9 6 1 5 10 15');
+        const extras = r.tokenDiff.filter((t) => t.status === 'extra');
+        expect(extras.map((t) => t.token)).toEqual(['9', '10', '15']);
+    });
+
+    it('matching tokens are marked match', () => {
+        const r = diffOutput('0 2 3 6 1 5', '0 2 3 9 6 1 5 10 15');
+        const matches = r.tokenDiff.filter((t) => t.status === 'match');
+        expect(matches.map((t) => t.token)).toEqual([
+            '0',
+            '2',
+            '3',
+            '6',
+            '1',
+            '5',
+        ]);
+    });
+
+    it('missing tokens are marked missing', () => {
+        const r = diffOutput('1 2 3 4', '1 2 3');
+        const missing = r.tokenDiff.filter((t) => t.status === 'missing');
+        expect(missing.map((t) => t.token)).toEqual(['4']);
+    });
+
+    it('tokens across multiple lines are flattened — swapped token produces missing + extra', () => {
+        // '3' is in expected but not received → missing; '4' is in received but not expected → extra
+        const r = diffOutput('1\n2\n3', '1\n2\n4');
+        const changed = r.tokenDiff.filter((t) => t.status !== 'match');
+        expect(changed).toHaveLength(2);
+        expect(changed.find((t) => t.status === 'missing')?.token).toBe('3');
+        expect(changed.find((t) => t.status === 'extra')?.token).toBe('4');
+    });
+
+    it('completely correct output has all match tokens', () => {
+        const r = diffOutput('1 2 3', '1 2 3');
+        expect(r.tokenDiff.every((t) => t.status === 'match')).toBe(true);
+    });
+
+    it('tokenDiff is empty when both outputs are empty', () => {
+        const r = diffOutput('', '');
+        expect(r.tokenDiff).toHaveLength(0);
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,9 +111,29 @@ export type Run = {
     timeOut: boolean;
 };
 
+export type DiffLine = {
+    lineNumber: number;
+    expected: string | null;
+    received: string | null;
+    type: 'match' | 'changed' | 'missing' | 'extra';
+};
+
+export type TokenDiff = {
+    token: string;
+    status: 'match' | 'extra' | 'missing';
+};
+
+export type DiffResult = {
+    isMatch: boolean;
+    lines: DiffLine[];
+    summary: string;
+    tokenDiff: TokenDiff[];
+};
+
 export type RunResult = {
     pass: boolean | null;
     id: number;
+    diff?: DiffResult;
 } & Run;
 
 export type WebviewMessageCommon = {

--- a/src/utils/diffOutput.ts
+++ b/src/utils/diffOutput.ts
@@ -1,0 +1,112 @@
+import { DiffLine, DiffResult, TokenDiff } from '../types';
+
+function normalizeLines(raw: string): string[] {
+    return raw
+        .replace(/\r\n/g, '\n')
+        .trim()
+        .split('\n')
+        .map((l) => l.trim());
+}
+
+function tokenize(raw: string): string[] {
+    return raw
+        .replace(/\r\n/g, '\n')
+        .trim()
+        .split(/\s+/)
+        .filter((t) => t.length > 0);
+}
+
+/**
+ * LCS-based token diff.
+ * Returns a flat list of tokens annotated as match / extra / missing.
+ *   match   → token exists in both at the right position
+ *   extra   → token is in received but not expected (pink + strikethrough)
+ *   missing → token is in expected but not received (blue underline)
+ */
+function lcsTokenDiff(expected: string[], received: string[]): TokenDiff[] {
+    const m = expected.length;
+    const n = received.length;
+
+    // Build DP table
+    const dp: number[][] = Array.from({ length: m + 1 }, () =>
+        new Array(n + 1).fill(0),
+    );
+    for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+            dp[i][j] =
+                expected[i - 1] === received[j - 1]
+                    ? dp[i - 1][j - 1] + 1
+                    : Math.max(dp[i - 1][j], dp[i][j - 1]);
+        }
+    }
+
+    // Backtrack to build diff
+    const result: TokenDiff[] = [];
+    let i = m;
+    let j = n;
+
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && expected[i - 1] === received[j - 1]) {
+            result.unshift({ token: received[j - 1], status: 'match' });
+            i--;
+            j--;
+        } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+            result.unshift({ token: received[j - 1], status: 'extra' });
+            j--;
+        } else {
+            result.unshift({ token: expected[i - 1], status: 'missing' });
+            i--;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Compares expected and received program output.
+ * Produces both a line-level summary and a token-level LCS diff
+ * for GFG-style inline rendering.
+ *
+ * @param expected - The expected output string (from the testcase)
+ * @param received - The actual stdout from the program run
+ */
+export function diffOutput(expected: string, received: string): DiffResult {
+    // Line-level diff (for summary counts)
+    const expLines = normalizeLines(expected);
+    const recLines = normalizeLines(received);
+    const maxLen = Math.max(expLines.length, recLines.length);
+    const lines: DiffLine[] = [];
+
+    for (let i = 0; i < maxLen; i++) {
+        const exp = i < expLines.length ? expLines[i] : null;
+        const rec = i < recLines.length ? recLines[i] : null;
+
+        let type: DiffLine['type'];
+        if (exp === null) {
+            type = 'extra';
+        } else if (rec === null) {
+            type = 'missing';
+        } else if (exp === rec) {
+            type = 'match';
+        } else {
+            type = 'changed';
+        }
+
+        lines.push({ lineNumber: i + 1, expected: exp, received: rec, type });
+    }
+
+    const isMatch = lines.every((l) => l.type === 'match');
+    const diffCount = lines.filter((l) => l.type !== 'match').length;
+    const summary = isMatch
+        ? 'All lines match.'
+        : `${diffCount} line${diffCount === 1 ? '' : 's'} differ${
+              diffCount === 1 ? 's' : ''
+          }.`;
+
+    // Token-level LCS diff (for inline GFG-style rendering)
+    const expTokens = tokenize(expected);
+    const recTokens = tokenize(received);
+    const tokenDiff = lcsTokenDiff(expTokens, recTokens);
+
+    return { isMatch, lines, summary, tokenDiff };
+}

--- a/src/webview/frontend/CaseView.tsx
+++ b/src/webview/frontend/CaseView.tsx
@@ -1,4 +1,4 @@
-import { Case, VSToWebViewMessage } from '../../types';
+import { Case, VSToWebViewMessage, DiffResult, TokenDiff } from '../../types';
 import { useState, createRef, useEffect } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import React from 'react';
@@ -247,6 +247,12 @@ export default function CaseView(props: {
                             </>
                         </div>
                     )}
+                    {result != null && !result.pass && result.diff != null && (
+                        <DiffView
+                            diff={result.diff}
+                            copyToClipboard={copyToClipboard}
+                        />
+                    )}
                     {stderror && stderror.length > 0 && (
                         <>
                             Standard Error:
@@ -260,6 +266,85 @@ export default function CaseView(props: {
                 </>
             )}
         </div>
+    );
+}
+
+function DiffView({
+    diff,
+    copyToClipboard,
+}: {
+    diff: DiffResult;
+    copyToClipboard: (text: string) => void;
+}) {
+    if (diff.isMatch) {
+        return null;
+    }
+
+    // Plain text version for clipboard
+    const plainText = diff.tokenDiff.map((t) => t.token).join(' ');
+
+    return (
+        <div className="textarea-container">
+            Output Difference:
+            <div
+                className="clipboard"
+                onClick={() => copyToClipboard(plainText)}
+                title="Copy to clipboard"
+            >
+                Copy
+            </div>
+            <div
+                className="selectable received-textarea"
+                style={{
+                    padding: '6px',
+                    lineHeight: '2',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                }}
+            >
+                {diff.tokenDiff.map((t, idx) => (
+                    <TokenChip key={idx} token={t} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function TokenChip({ token }: { token: TokenDiff }) {
+    if (token.status === 'match') {
+        return <span style={{ marginRight: '4px' }}>{token.token}</span>;
+    }
+
+    if (token.status === 'extra') {
+        return (
+            <span
+                style={{
+                    marginRight: '4px',
+                    backgroundColor:
+                        'var(--vscode-diffEditor-removedTextBackground)',
+                    textDecoration: 'line-through',
+                    borderRadius: '3px',
+                    padding: '1px 3px',
+                }}
+            >
+                {token.token}
+            </span>
+        );
+    }
+
+    // missing — in expected but not received
+    return (
+        <span
+            style={{
+                marginRight: '4px',
+                backgroundColor:
+                    'var(--vscode-diffEditor-insertedTextBackground)',
+                borderRadius: '3px',
+                padding: '1px 3px',
+            }}
+        >
+            {token.token}
+        </span>
     );
 }
 

--- a/src/webview/processRunSingle.ts
+++ b/src/webview/processRunSingle.ts
@@ -4,6 +4,7 @@ import { getBinSaveLocation, compileFile } from '../compiler';
 import { saveProblem } from '../parser';
 import { runTestCase, deleteBinary } from '../executions';
 import { isResultCorrect } from '../judge';
+import { diffOutput } from '../utils/diffOutput';
 import * as vscode from 'vscode';
 import { getJudgeViewProvider } from '../extension';
 import { getIgnoreSTDERRORPref } from '../preferences';
@@ -58,6 +59,7 @@ export const runSingleAndSave = async (
     const result: RunResult = {
         ...run,
         pass: didError ? false : isResultCorrect(testCase, run.stdout),
+        diff: didError ? undefined : diffOutput(testCase.output, run.stdout),
         id,
     };
 


### PR DESCRIPTION
## 🚀 Feature Description

When a test case fails (Wrong Answer), CPH currently shows expected and received
outputs as two raw text blocks — the user has to manually scan both to find where
they differ. This is slow and error-prone, especially during timed contests.

This PR adds an **inline token-level diff view** ("Output Difference") that appears
below the Received Output box on failure. It uses **LCS (Longest Common Subsequence)**
on whitespace-split tokens to highlight exactly which tokens are wrong:

- 🟩 **Missing tokens** (expected but not received) — green highlighted background
- 🟥 **Extra tokens** (received but not expected) — red background + ~~strikethrough~~
- ⬜ **Matching tokens** — plain text, no decoration

This is the same approach used by LeetCode, GeeksforGeeks, and Codeforces's own
[wcmp.cpp](https://github.com/MikeMirzayanov/testlib/blob/master/checkers/wcmp.cpp)
token comparator from testlib. CPH already does the pass/fail verdict — this feature
brings the same token-level visibility into the local dev panel.

The diff panel includes a **Copy** button and uses the project's existing CSS classes
(`textarea-container`, `clipboard`, `received-textarea`), so it inherits the current
theme styling automatically via VS Code's native diff editor CSS variables.

## 🔗 Related Issue

Closes #628 

## 🛠️ Changes Made

### New Files
- [x] `src/utils/diffOutput.ts` — Core diff engine:
  - `normalizeLines()` — CRLF → LF, trailing whitespace trimming
  - `tokenize()` — whitespace-split tokenizer
  - `lcsTokenDiff()` — LCS DP algorithm for token-level comparison
  - `diffOutput()` — produces both line-level summary and token-level diffs
- [x] `src/tests/diffOutput.test.ts` — 17 unit tests:
  - Line-level: exact match, changed/missing/extra lines, CRLF normalization, whitespace trimming
  - Token-level: extra/missing/match tokens, multi-line flattening, empty output edge case

### Modified Files
- [x] `src/types.ts` — Added `DiffLine`, `TokenDiff`, `DiffResult` types; added optional `diff?: DiffResult` on `RunResult`
- [x] `src/webview/processRunSingle.ts` — Imported `diffOutput`, called alongside `isResultCorrect()`, result attached to `RunResult`
- [x] `src/webview/frontend/CaseView.tsx` — Added `DiffView` and `TokenChip` React components with Copy button

### Key Design Decisions
- **No new message types** — `diff` rides inside existing `RunResult` via `run-single-result` postMessage. `App.tsx` untouched.
- **No circular dependencies** — all types in `types.ts`, utility imports one-way.
- **Theme-aware** — uses `var(--vscode-diffEditor-removedTextBackground)` and `var(--vscode-diffEditor-insertedTextBackground)`.
- **Minimal footprint** — 5 files, 329 insertions, 1 deletion. Zero new dependencies.

## 🧪 How to Test

### Automated Tests
1. Pull this branch
2. Run `npm install`
3. Run `npm run test` → **24/24 tests pass** (17 new + 7 existing)
4. Run `npm run test-compile` → `tsc` compiles clean, zero errors
5. Run `npx eslint src/utils/diffOutput.ts src/webview/frontend/CaseView.tsx src/webview/processRunSingle.ts src/types.ts src/tests/diffOutput.test.ts` → zero lint errors

### Manual Testing
1. Run `npm run webpack` (builds both frontend + extension)
2. Press **F5** to launch the Extension Development Host
3. Create a test file and press `Ctrl+Alt+B` to open the CPH panel
4. Add a test case where the expected output differs from the actual output
5. Click ▶ Run and observe the **"Output Difference"** section below Received Output
6. Verify: matching tokens are plain, extra tokens have red background + strikethrough, missing tokens have green background
7. Click **Copy** on the diff section — tokens are copied as space-joined text
8. Fix the code so it passes → verify the diff section disappears

### Test Cases Used

**Test 1 — Single token off-by-one (`p1.cpp`):**
Sum of array outputs `14` instead of `15` (off-by-one bug: `sum - 1`).
Diff shows: `15` (green/missing) and `14` (red/strikethrough/extra).

**Test 2 — Extra token in multi-line output (`p2.cpp`):**
Sorted array printer injects an extra `done` token between lines.
Diff shows: `1` ~~`done`~~ `2` `3` — the spurious `done` token is immediately visible.

**Test 3 — Wrong token in array doubling (`p3.cpp`):**
Array doubler forgets to double index 3: outputs `4` instead of `8`.
Diff shows: `2` `4` `6` `8` ~~`4`~~ `10` `12` — the wrong `4` and missing `8` are highlighted.

## 📸 Screenshots / Demos

### Test 1 — Single token diff (sum off-by-one)
| Before | After |
| :--- | :--- |
| <img width="271" height="377" alt="Before_SS1" src="https://github.com/user-attachments/assets/c795abec-de0d-41db-a3cc-70b7fcf3bb0d" /> | <img width="253" height="427" alt="After_SS1" src="https://github.com/user-attachments/assets/889da9a2-800e-4fd6-bb5e-83dab5afa74a" /> |


Expected `15`, received `14`. The diff section shows `15` (green) and `14` (red + strikethrough).

### Test 2 — Extra token in multi-line output
| Before | After |
| :--- | :--- |
|<img width="269" height="446" alt="Before_SS2" src="https://github.com/user-attachments/assets/24e4ab25-43c2-4dab-9d0d-51f4e902f092" />|<img width="253" height="475" alt="After_SS2" src="https://github.com/user-attachments/assets/723c6405-27dd-4bd8-a848-d6b30de21c44" />|

Expected `1 2 3`, received `1 done 2 3`. The extra `done` token is highlighted with red + strikethrough.

### Test 3 — Wrong token in array doubling
| Before | After |
| :--- | :--- |
| <img width="270" height="403" alt="Before_SS3" src="https://github.com/user-attachments/assets/65ee61e8-1d72-4a70-b6d8-22b216bc1d88" />| <img width="247" height="429" alt="After_SS3" src="https://github.com/user-attachments/assets/a1c300ec-d95e-4d9a-aeff-63fc9daec2b0" />|

Expected `2 4 6 8 10 12`, received `2 4 6 4 10 12`. The wrong `4` (extra) and missing `8` are highlighted.

---

## ✅ Checklist
- [x] My code follows the style guidelines of this project (prettier + eslint clean)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (JSDoc on `diffOutput`, `lcsTokenDiff`)
- [x] I have added tests that prove my feature works (17 new unit tests)
- [x] New and existing unit tests pass locally with my changes (24/24 pass)
- [x] My changes generate no new warnings or errors
- [x] I have tested the feature manually in the Extension Development Host with multiple test scenarios
