### PR TITLE
Expand Codeforces URL matching and improve domain validation

### DIFF
--- a/src/submit.ts
+++ b/src/submit.ts
@@ -2,6 +2,7 @@ import { getProblem } from './parser';
 import * as vscode from 'vscode';
 import { storeSubmitProblem, submitKattisProblem } from './companion';
 import { getJudgeViewProvider } from './extension';
+import { isCodeforcesUrl } from './utils';
 import telmetry from './telmetry';
 
 export const submitToKattis = async () => {
@@ -75,7 +76,7 @@ export const submitToCodeForces = async () => {
         return;
     }
 
-    if (url.hostname !== 'codeforces.com') {
+    if (!isCodeforcesUrl(url)) {
         vscode.window.showErrorMessage('Not a codeforces problem.');
         return;
     }
@@ -90,8 +91,10 @@ export const submitToCodeForces = async () => {
 export const getProblemName = (problemUrl: string): string => {
     const regexPatterns = [
         /\/contest\/(\d+)\/problem\/(\w+)/,
-        /\/problemset\/problem\/(\d+)\/(\w+)/,
         /\/gym\/(\d+)\/problem\/(\w+)/,
+        /\/problemset\/problem\/(\d+)\/(\w+)/,
+        /\/problemset\/gymProblem\/(\d+)\/(\w+)/,
+        /\/problemsets\/acmsguru\/problem\/(\d+)\/(\w+)/,
     ];
 
     for (const regex of regexPatterns) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,7 +153,7 @@ export const isValidLanguage = (srcPath: string): boolean => {
 };
 
 export const isCodeforcesUrl = (url: URL): boolean => {
-    return url.hostname.includes('codeforces.com');
+    return url.hostname.endsWith('codeforces.com');
 };
 export const isLuoguUrl = (url: URL): boolean => {
     return url.hostname.indexOf('luogu.com.cn') !== -1;

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -408,13 +408,13 @@ function Judge(props: {
             return null;
         }
         if (
-            url.hostname !== 'codeforces.com' &&
+            !url.hostname.endsWith('codeforces.com') &&
             url.hostname !== 'open.kattis.com'
         ) {
             return null;
         }
 
-        if (url.hostname == 'codeforces.com') {
+        if (url.hostname.endsWith('codeforces.com')) {
             return (
                 <button className="btn" onClick={submitCf}>
                     <span className="icon">


### PR DESCRIPTION
- Update `isCodeforcesUrl` to use `endsWith` for better subdomain support (e.g., m1.codeforces.com or a group with a subdomain).
- Add regex patterns for Gym problems, ACM-GURU, and specific problemset variants in `getProblemName`.
- Refactor Codeforces submission check to use the centralized `isCodeforcesUrl` utility.
- Update webview logic to recognize Codeforces subdomains for the submit button visibility.