### PR TITLE
feat: add preference to hide output difference in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,6 +413,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "%cph.general.showLiveUserCount.description%"
+                },
+                "cph.general.hideOutputDifference": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, the UI will hide the inline output difference by default. Users can toggle and this will be remembered."
                 }
             }
         }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -105,6 +105,9 @@ export const getRemoteServerAddressPref = (): string =>
 export const getLiveUserCountPref = (): boolean =>
     getPreference('general.showLiveUserCount') || false;
 
+export const getHideOutputDifferencePref = (): boolean =>
+    getPreference('general.hideOutputDifference') || false;
+
 export const getDefaultLangPref = (): string | null => {
     const pref = getPreference('general.defaultLanguage');
     if (pref === 'none' || pref == ' ' || !pref) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,8 @@ export type prefSection =
     | 'general.defaultLanguageTemplateFileLocation'
     | 'general.doTemplateFileVariableReplacement'
     | 'general.remoteServerAddress'
-    | 'general.showLiveUserCount';
+    | 'general.showLiveUserCount'
+    | 'general.hideOutputDifference';
 
 export type Language = {
     name: LangNames;
@@ -194,6 +195,11 @@ export type GetExtLogs = {
     command: 'get-ext-logs';
 };
 
+export type SetHideOutputDiff = {
+    command: 'set-hide-output-diff';
+    value: boolean;
+};
+
 export type WebviewToVSEvent =
     | RunAllCommand
     | GetInitialProblem
@@ -206,7 +212,8 @@ export type WebviewToVSEvent =
     | OnlineJudgeEnv
     | SubmitKattis
     | OpenUrl
-    | GetExtLogs;
+    | GetExtLogs
+    | SetHideOutputDiff;
 
 export type RunningCommand = {
     command: 'running';

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -13,6 +13,8 @@ import {
     getLiveUserCountPref,
     getRetainWebviewContextPref,
     getDefaultOnlineJudge,
+    getHideOutputDifferencePref,
+    updatePreference,
 } from '../preferences';
 import { setOnlineJudgeEnv } from '../compiler';
 import { translations } from './translations';
@@ -111,6 +113,23 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
 
                     case 'get-initial-problem': {
                         this.getInitialProblem();
+                        break;
+                    }
+
+                    case 'set-hide-output-diff': {
+                        // message.value expected boolean
+                        try {
+                            await updatePreference(
+                                'general.hideOutputDifference',
+                                message.value,
+                                vscode.ConfigurationTarget.Global,
+                            );
+                        } catch (err) {
+                            globalThis.logger.error(
+                                'Failed to update preference',
+                                err,
+                            );
+                        }
                         break;
                     }
 
@@ -283,6 +302,7 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                         window.generatedJsonUri = '${generatedJsonUri}';
                         window.remoteServerAddress = '${remoteServerAddress}';
                         window.showLiveUserCount = ${showLiveUserCount};
+                        window.showOutputDifference = ${!getHideOutputDifferencePref()};
                         window.translations = ${JSON.stringify(translation)};
 
                         document.addEventListener(

--- a/src/webview/frontend/CaseView.tsx
+++ b/src/webview/frontend/CaseView.tsx
@@ -266,12 +266,15 @@ export default function CaseView(props: {
                             </>
                         </div>
                     )}
-                    {result != null && !result.pass && result.diff != null && (
-                        <DiffView
-                            diff={result.diff}
-                            copyToClipboard={copyToClipboard}
-                        />
-                    )}
+                    {result != null &&
+                        !result.pass &&
+                        result.diff != null &&
+                        (window as any).showOutputDifference !== false && (
+                            <DiffView
+                                diff={result.diff}
+                                copyToClipboard={copyToClipboard}
+                            />
+                        )}
                     {stderror && stderror.length > 0 && (
                         <div style={{ userSelect: 'text' }}>
                             {t('standardError')}
@@ -318,13 +321,16 @@ function DiffView({
     return (
         <div className="textarea-container">
             {t('outputDifference')}
-            <div
-                className="clipboard"
-                onClick={() => copyToClipboard(plainText)}
-                title={t('copiedToClipboard')}
-            >
-                {t('copy')}
+            <div style={{ display: 'inline-flex', gap: '6px', float: 'right' }}>
+                <div
+                    className="clipboard"
+                    onClick={() => copyToClipboard(plainText)}
+                    title={t('copiedToClipboard')}
+                >
+                    {t('copy')}
+                </div>
             </div>
+            <div style={{ clear: 'both' }} />
             <div
                 className="selectable received-textarea"
                 style={{


### PR DESCRIPTION
This PR introduces a new setting cph.general.hideOutputDifference (default: false) that allows users to hide the output difference panel.