### PR TITLE
Add date/time template variables

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -121,6 +121,8 @@ Several options are available to customize the extension. Open VS Code settings
 -   For example:
     -   $name$ - problem name
     -   $url$ - problem url
+    -   $date$ - local date in YYYY-MM-DD
+    -   $time$ - local time in HH:MM:SS
 -   For a full list, turn on debug mode in the Competitive Companion extension
     preferences (Right Click on Extension>Manage extension>Preferences) and use
     the JSON keys shown in the console (F12 > Navigate to the Console tab) after

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -297,7 +297,24 @@ const handleNewProblem = async (problem: Problem) => {
                         );
                     }
                     if (doTemplateFileVariableReplacement()) {
-                        for (const [key, value] of Object.entries(problem)) {
+                        const now = new Date();
+                        const pad2 = (value: number) =>
+                            value.toString().padStart(2, '0');
+                        const date = `${now.getFullYear()}-${pad2(
+                            now.getMonth() + 1,
+                        )}-${pad2(now.getDate())}`;
+                        const time = `${pad2(now.getHours())}:${pad2(
+                            now.getMinutes(),
+                        )}:${pad2(now.getSeconds())}`;
+                        const templateVariables: Record<string, unknown> = {
+                            ...problem,
+                            date,
+                            time,
+                        };
+
+                        for (const [key, value] of Object.entries(
+                            templateVariables,
+                        )) {
                             let replaceWith = JSON.stringify(value);
                             replaceWith = replaceWith.substring(
                                 1,


### PR DESCRIPTION
This PR adds two new template variables, `$date$` and `$time$`, which are replaced with the local date (YYYY-MM-DD) and local time (HH:MM:SS) when creating a new problem file from Competitive Companion.

### Changes:
- Added `$date$` and `$time$` variables to the template replacement logic in `src/companion.ts`.
- Documented the new placeholders in `docs/user-guide.md`.'