### PR TITLE
feat: support $CURSOR_PLACEHOLDER in templates

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -108,10 +108,11 @@ Several options are available to customize the extension. Open VS Code settings
 ## Default Language Templates
 
 -   The path of the template that will be loaded when a new file of the default
-    language is created by Competitive Companion
+    language is created by Competitive Companion.
 -   For Java Users, the template shall be in the format where class name is
     `CLASS_NAME` as the file name so that CLASS_NAME in the code gets auto
-    replaced. \
+    replaced.
+-   **Cursor Placement**: You can place `$CURSOR_PLACEHOLDER` in your template. When a new file is created, the cursor will automatically be moved to this position, and the placeholder string will be removed.
     ![Templates](img/templateSettings.png) ![Templates](img/javaTemplate.png)
 
 ### Template Variable Replacement

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -335,7 +335,29 @@ const handleNewProblem = async (problem: Problem) => {
     saveProblem(srcPath, problem);
     const doc = await vscode.workspace.openTextDocument(srcPath);
 
-    await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+    const editor = await vscode.window.showTextDocument(
+        doc,
+        vscode.ViewColumn.One,
+    );
+
+    // Move cursor to the first occurrence of $CURSOR_PLACEHOLDER and remove it
+    const cursorPlaceholder = '$CURSOR_PLACEHOLDER';
+    const text = doc.getText();
+    const index = text.indexOf(cursorPlaceholder);
+    if (index !== -1) {
+        const start = doc.positionAt(index);
+        const end = doc.positionAt(index + cursorPlaceholder.length);
+        await editor.edit((editBuilder) => {
+            editBuilder.delete(new vscode.Range(start, end));
+        });
+        // Set selection and reveal AFTER the edit so it isn't reset
+        editor.selection = new vscode.Selection(start, start);
+        editor.revealRange(
+            new vscode.Range(start, start),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    }
+
     getJudgeViewProvider().extensionToJudgeViewMessage({
         command: 'new-problem',
         problem,


### PR DESCRIPTION
Closes #652 

### Description
This PR adds support for a `$CURSOR_PLACEHOLDER` variable in template files.

**How it works:**
* When a new problem file is created using Competitive Companion, the extension looks for `$CURSOR_PLACEHOLDER` in the template contents.
* If found, the editor moves the cursor to that position, scrolls it into center view, and removes the placeholder text.
* If not present, the template loads normally without any changes.

Documentation has also been updated in `docs/user-guide.md` to explain how to use this feature.