### PR TITLE
fix: preserve leading newlines during output comparison

### DIFF
--- a/src/tests/diffOutput.test.ts
+++ b/src/tests/diffOutput.test.ts
@@ -36,6 +36,11 @@ describe('diffOutput — line-level', () => {
         expect(diffOutput('42  \n', '42\n').isMatch).toBe(true);
     });
 
+    it('does not ignore leading newlines', () => {
+        expect(diffOutput('42\n', '\n42\n').isMatch).toBe(false);
+        expect(diffOutput('\n42\n', '42\n').isMatch).toBe(false);
+    });
+
     it('multiline exact match', () => {
         const r = diffOutput('1\n2\n3\n', '1\n2\n3\n');
         expect(r.isMatch).toBe(true);

--- a/src/utils/diffOutput.ts
+++ b/src/utils/diffOutput.ts
@@ -3,15 +3,15 @@ import { DiffLine, DiffResult, TokenDiff } from '../types';
 function normalizeLines(raw: string): string[] {
     return raw
         .replace(/\r\n/g, '\n')
-        .trim()
+        .replace(/\s+$/, '') // trim trailing whitespace and trailing newlines only
         .split('\n')
-        .map((l) => l.trim());
+        .map((l) => l.trimRight()); // trim only trailing whitespace of each line
 }
 
 function tokenize(raw: string): string[] {
     return raw
         .replace(/\r\n/g, '\n')
-        .trim()
+        .replace(/\s+$/, '') // trim trailing whitespace and trailing newlines only
         .split(/(\n|[ \t]+)/)
         .filter((t) => t !== undefined && t.length > 0);
 }


### PR DESCRIPTION
### Description
This PR fixes #642 where leading newlines in the program's output were being ignored during evaluation. 

**Changes:**
- Modified `normalizeLines` and `tokenize` in `src/utils/diffOutput.ts` to use a regular expression (`.replace(/\s+$/, '')`) that only trims trailing whitespaces and trailing newlines, thereby preserving any leading formatting.
- Added unit tests in `src/tests/diffOutput.test.ts` to ensure that outputs with mismatches in leading newlines are correctly flagged as incorrect (`isMatch: false`).