### PR TITLE
added submit button for cses problems and linked it with CPH-Submit Extension

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,10 @@ export type SubmitCf = {
     command: 'submitCf';
 } & WebviewMessageCommon;
 
+export type SubmitCSES = {
+    command: 'submitCSES';
+} & WebviewMessageCommon;
+
 export type SubmitKattis = {
     command: 'submitKattis';
 } & WebviewMessageCommon;
@@ -224,6 +228,7 @@ export type WebviewToVSEvent =
     | SaveCommand
     | DeleteTcsCommand
     | SubmitCf
+    | SubmitCSES
     | OnlineJudgeEnv
     | SubmitKattis
     | OpenUrl

--- a/src/webview/JudgeView.ts
+++ b/src/webview/JudgeView.ts
@@ -90,6 +90,11 @@ class JudgeViewProvider implements vscode.WebviewViewProvider {
                         storeSubmitProblem(message.problem);
                         break;
                     }
+
+                    case 'submitCSES': {
+                        storeSubmitProblem(message.problem);
+                        break;
+                    }
                     case 'submitKattis': {
                         submitKattisProblem(message.problem);
                         break;

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -570,7 +570,6 @@ function Judge(props: {
         if (
             !url.hostname.endsWith('codeforces.com') &&
             url.hostname !== 'open.kattis.com' &&
-            !url.hostname.endsWith('codechef.com') &&
             !url.hostname.endsWith('cses.fi')
         ) {
             return null;

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -412,6 +412,15 @@ function Judge(props: {
 
         setWaitingForSubmit(true);
     };
+    
+    const submitCSES = () => {
+        sendMessageToVSCode({
+            command: 'submitCSES',
+            problem,
+        });
+
+        setWaitingForSubmit(true);
+    };
 
     const debounceFocusLast = () => {
         setTimeout(() => {
@@ -562,7 +571,9 @@ function Judge(props: {
         }
         if (
             !url.hostname.endsWith('codeforces.com') &&
-            url.hostname !== 'open.kattis.com'
+            url.hostname !== 'open.kattis.com' &&
+            !url.hostname.endsWith('codechef.com') &&
+            !url.hostname.endsWith('cses.fi')
         ) {
             return null;
         }
@@ -599,6 +610,18 @@ function Judge(props: {
                         </>
                     )}
                 </div>
+            );
+        } else if (
+            url.hostname == 'cses.fi' ||
+            url.hostname.endsWith('cses.fi')
+        ) {
+            return (
+                <button className="btn btn-block" onClick={submitCSES}>
+                    <span className="icon">
+                        <i className="codicon codicon-cloud-upload"></i>
+                    </span>{' '}
+                    {t('submit')}
+                </button>
             );
         }
     };

--- a/src/webview/frontend/App.tsx
+++ b/src/webview/frontend/App.tsx
@@ -412,7 +412,6 @@ function Judge(props: {
 
         setWaitingForSubmit(true);
     };
-    
     const submitCSES = () => {
         sendMessageToVSCode({
             command: 'submitCSES',
@@ -421,7 +420,6 @@ function Judge(props: {
 
         setWaitingForSubmit(true);
     };
-
     const debounceFocusLast = () => {
         setTimeout(() => {
             setFocusLast(false);


### PR DESCRIPTION
[Description](<img width="1920" height="1080" alt="Screenshot (262)" src="https://github.com/user-attachments/assets/5b15c7f6-33b7-4602-a6e0-a78d3c5ea6e0" />)
This PR introduces the foundational support within the editor to enable automated submissions for CSES problems, linking them directly to the existing CPH submit button.

Fixes: #327

Workflow & Architecture

Problem Fetching: The user parses a CSES problem using the Competitive Companion extension.

Triggering Submission: The user hits the standard "Submit" button inside the CPH interface.

Payload Generation (This PR): CPH captures the request, maps the internal editor language ID to the corresponding CSES language format, and prepares the submission payload.

Handoff: The payload is dispatched to the local CPH endpoint so the browser extension can pick it up.

(Note: The second half of this workflow—creating a pseudo-solution file using the DataTransfer API to bypass Chrome's local file-picker security constraints, and automating the DOM submission—will be handled in a companion PR to the cph-submit repository).

https://github.com/user-attachments/assets/4cc76e61-e951-44da-88f9-6da359077724

