### PR TITLE
fix: case-insensitive extension validation and robust language detection

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -91,6 +91,7 @@
     "cph.submit.notKattis": "Not a kattis problem.",
     "cph.submit.notCodeforces": "Not a codeforces problem.",
     "cph.utils.unsupported": "Unsupported file extension. Only these types are valid: {0}",
+    "cph.utils.noActiveEditor": "No active editor found.",
     "cph.preferences.invalidSaveLocation": "Invalid save location, reverting to default. path not exists: {0}",
     "cph.processRunSingle.invalidChecker": "Custom checker script not found at '{0}'"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -91,6 +91,7 @@
     "cph.submit.notKattis": "不是 Kattis 题目。",
     "cph.submit.notCodeforces": "不是 Codeforces 题目。",
     "cph.utils.unsupported": "不支持的文件扩展名。只有以下类型有效：{0}",
+    "cph.utils.noActiveEditor": "未发现活动中的编辑器。",
     "cph.preferences.invalidSaveLocation": "保存位置无效，正在恢复为默认值。路径不存在：{0}",
     "cph.processRunSingle.invalidChecker": "在“{0}”处未找到自定义判题脚本"
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,12 +40,16 @@ const oc = vscode.window.createOutputChannel('cph');
  * Get language based on file extension
  */
 export const getLanguage = (srcPath: string): Language => {
-    const extension = path.extname(srcPath).split('.').pop();
+    const extension = path.extname(srcPath).toLowerCase().replace('.', '');
     let langName: string | void = undefined;
     for (const [lang, ext] of Object.entries(config.extensions)) {
         if (ext === extension) {
             langName = lang;
         }
+    }
+
+    if (langName === undefined && (config.extensions as any)[extension] !== undefined) {
+        langName = extension;
     }
 
     if (langName === undefined) {
@@ -148,9 +152,8 @@ export const getLanguage = (srcPath: string): Language => {
 };
 
 export const isValidLanguage = (srcPath: string): boolean => {
-    return config.supportedExtensions.includes(
-        path.extname(srcPath).split('.')[1],
-    );
+    const ext = path.extname(srcPath).toLowerCase().replace('.', '');
+    return config.supportedExtensions.includes(ext);
 };
 
 export const isCodeforcesUrl = (url: URL): boolean => {
@@ -194,6 +197,12 @@ export const randomId = (index: number | null) => {
  * unsupported.
  */
 export const checkUnsupported = (srcPath: string): boolean => {
+    if (srcPath === '') {
+        vscode.window.showErrorMessage(
+            localize('cph.utils.noActiveEditor', 'No active editor found.'),
+        );
+        return true;
+    }
     if (!isValidLanguage(srcPath)) {
         vscode.window.showErrorMessage(
             localize(


### PR DESCRIPTION
This PR addresses issues with file extension validation and language detection, particularly on case-insensitive file systems like Windows.

### Changes:
- **Case-Insensitive Validation:** Updated `isValidLanguage` and `getLanguage` to normalize extensions to lowercase before checking. This fixes issues where files like `f.CPP` were incorrectly flagged as unsupported.
- **Improved Language Detection:** Refactored `getLanguage` to correctly handle extensions like `.cc` and `.cxx` by checking both language keys and supported extension values.
- **Enhanced Error Feedback:** Improved `checkUnsupported` to provide a specific "No active editor found" message when no file is active, instead of the misleading "Unsupported file extension" error.
- **Localization:** Added translations for the new error message in English and Simplified Chinese.

These changes improve the user experience and prevent confusing errors during file renaming or creation.
