### PR TITLE
Fix compiled binary cleanup on macOS

### DIFF
--- a/src/executions.ts
+++ b/src/executions.ts
@@ -199,16 +199,10 @@ export const deleteBinary = (language: Language, binPath: string) => {
     }
     globalThis.logger.log('Deleting binary', binPath);
     try {
-        const isLinux = platform() == 'linux';
+        const isWindows = platform() === 'win32';
         const isFile = path.extname(binPath);
 
-        if (isLinux) {
-            if (isFile) {
-                spawn('rm', [binPath]);
-            } else {
-                spawn('rm', ['-r', binPath]);
-            }
-        } else {
+        if (isWindows) {
             const nrmBinPath = '"' + binPath + '"';
             if (isFile) {
                 spawn('cmd.exe', ['/c', 'del', nrmBinPath], {
@@ -219,6 +213,10 @@ export const deleteBinary = (language: Language, binPath: string) => {
                     windowsVerbatimArguments: true,
                 });
             }
+        } else if (isFile) {
+            spawn('rm', [binPath]);
+        } else {
+            spawn('rm', ['-r', binPath]);
         }
     } catch (err) {
         globalThis.logger.error('Error while deleting binary', err);


### PR DESCRIPTION
Closes #711

## Summary
- `deleteBinary` only used `rm` on Linux; macOS fell through to Windows `cmd.exe`/`del`, so compiled artifacts were never removed
- Now uses Windows deletion only when `platform() === 'win32'`, and `rm` for all other platforms (Linux + macOS)

## Test plan
- [x] TypeScript compiles (`npm run test-compile`)
- [x] On macOS: run testcases on a `.kt` or `.cpp` file, confirm `.jar`/`.bin` is removed after run completes